### PR TITLE
Add argument validation to all api methods

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,7 +6,7 @@ on:
       - gh-pages
 
 jobs:
-  build_and_test:
+  test_and_upload_coverage:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,23 @@
+name: Codecov
+
+on: 
+  push:
+    branches-ignore:
+      - gh-pages
+
+jobs:
+  build_and_test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.100
+    - name: Test with dotnet
+      run: dotnet test --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Code coverage
+      uses: codecov/codecov-action@v1
+

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,6 +19,5 @@ jobs:
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet
-      run: dotnet test --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-    - name: Code coverage
-      uses: codecov/codecov-action@v1
+      run: dotnet test
+

--- a/README.md
+++ b/README.md
@@ -11,9 +11,20 @@
 
 ## Installation
 
-Installation can be done through installation of the [NuGet package](https://www.nuget.org/packages/PVOutput.Net/).
+Installation can be done through installation of the [NuGet package](https://www.nuget.org/packages/PVOutput.Net/):
 
-## Usage
+```posh
+PM> Install-Package PVOutput.Net
+```
+
+## Support
+
+This library is targeting .NET Standard 2.0 and above. For full compatibility details, check the [Microsoft Docs](https://docs.microsoft.com/nl-nl/dotnet/standard/net-standard#net-implementation-support).
+
+**Please note:** that the default branch of the repository is `develop`. This means that it can contain bugfixes/features that are not yet available in the NuGet package.
+See [master](https://github.com/pyrocumulus/pvoutput.net/tree/master) for the source code, that was used for building the NuGet package.
+
+## Basic usage
 
 ### Getting data out of PVOutput.org
 
@@ -60,7 +71,7 @@ For more information on usage, please see the [documentation](https://pyrocumulu
 
 ## API Coverage
 
-The library covers almost nearly all the official PVOutput API exposes. See [documentation](https://pyrocumulus.github.io/pvoutput.net/) for details.
+The library covers almost all of the methods the official PVOutput API exposes. See [documentation](https://pyrocumulus.github.io/pvoutput.net/) for details.
 
 ## Building the project
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ var client = new PVOutputClient(apiKey: "myPvOutputKey", ownedSystemId: 1);
 // Request output for today
 var outputResponse = await client.Output.GetOutputForDateAsync(DateTime.Today);
 var output = outputResponse.Value;
-Console.WriteLine($"Output for date {output.OutputDate.ToShortDateString()},
-    {output.EnergyGenerated} Wh generated");
+Console.WriteLine($"Output for date {output.OutputDate.ToShortDateString()}, {output.EnergyGenerated} Wh generated");
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/PVOutput.Net.svg?logo=nuget)](https://www.nuget.org/packages/PVOutput.Net/)
 [![fuget](https://www.fuget.org/packages/PVOutput.Net/badge.svg)](https://www.fuget.org/packages/PVOutput.Net)
 ![.NET Core](https://img.shields.io/github/workflow/status/pyrocumulus/PVOutput.Net/.NET%20Core/develop)
+![Code coverage](https://img.shields.io/codecov/c/github/pyrocumulus/PVOutput.Net/develop)
 
 ## Installation
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -5,7 +5,15 @@
 
 ## Installation
 
-Installation can be done through installation of the [NuGet package](https://www.nuget.org/packages/PVOutput.Net/).
+Installation can be done through installation of the [NuGet package](https://www.nuget.org/packages/PVOutput.Net/):
+
+```posh
+PM> Install-Package PVOutput.Net
+```
+
+## Support
+
+This library is targeting .NET Standard 2.0 and above. For full compatibility details, check the [Microsoft Docs](https://docs.microsoft.com/nl-nl/dotnet/standard/net-standard#net-implementation-support).
 
 ## Usage
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -19,8 +19,7 @@ var client = new PVOutputClient(apiKey: "myPvOutputKey", ownedSystemId: 1);
 // Request output for today
 var outputResponse = await client.Output.GetOutputForDateAsync(DateTime.Today);
 var output = outputResponse.Value;
-Console.WriteLine($"Output for date {output.OutputDate.ToShortDateString()}, 
-    {output.EnergyGenerated} Wh generated");
+Console.WriteLine($"Output for date {output.OutputDate.ToShortDateString()}, {output.EnergyGenerated} Wh generated");
 ```
 
 ### Adding data to a system in PVOutput.org

--- a/src/PVOutput.Net/Modules/ExtendedService.cs
+++ b/src/PVOutput.Net/Modules/ExtendedService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
@@ -44,6 +45,9 @@ namespace PVOutput.Net.Modules
         /// <returns>List of extended data objects.</returns>
         public Task<PVOutputArrayResponse<IExtended>> GetExtendedDataForPeriodAsync(DateTime fromDate, DateTime toDate, int? limit = null, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate);
+            Guard.Argument(limit, nameof(limit)).LessThan(50);
+
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IExtended>(new ExtendedRequest() { FromDate = fromDate, ToDate = toDate, Limit = limit }, cancellationToken);
         }

--- a/src/PVOutput.Net/Modules/MissingService.cs
+++ b/src/PVOutput.Net/Modules/MissingService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
@@ -28,6 +29,8 @@ namespace PVOutput.Net.Modules
         /// <returns>List of missing dates</returns>
         public Task<PVOutputResponse<IMissing>> GetMissingDaysInPeriodAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate);
+
             var handler = new RequestHandler(Client);
             return handler.ExecuteSingleItemRequestAsync<IMissing>(new MissingRequest { FromDate = fromDate, ToDate = toDate }, cancellationToken);
         }

--- a/src/PVOutput.Net/Modules/OutputService.cs
+++ b/src/PVOutput.Net/Modules/OutputService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Dawn;
 using PVOutput.Net.Enums;
 using PVOutput.Net.Objects;
+using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
 using PVOutput.Net.Responses;
@@ -48,7 +49,8 @@ namespace PVOutput.Net.Modules
         /// <returns>Outputs for the requested period.</returns>
         public Task<PVOutputArrayResponse<IOutput>> GetOutputsForPeriodAsync(DateTime fromDate, DateTime toDate, bool getInsolation = false, int? systemId = null, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).Max(DateTime.Today);
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).IsNoFutureDate().NoTimeComponent();
+            Guard.Argument(fromDate, nameof(fromDate)).NoTimeComponent();
 
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IOutput>(new OutputRequest { FromDate = fromDate, ToDate = toDate, SystemId = systemId, Insolation = getInsolation }, cancellationToken);
@@ -79,7 +81,8 @@ namespace PVOutput.Net.Modules
         /// <returns>Team outputs Outputs for the requested period.</returns>
         public Task<PVOutputArrayResponse<ITeamOutput>> GetTeamOutputsForPeriodAsync(DateTime fromDate, DateTime toDate, int teamId, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).Max(DateTime.Today);
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).IsNoFutureDate().NoTimeComponent();
+            Guard.Argument(fromDate, nameof(fromDate)).NoTimeComponent();
 
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<ITeamOutput>(new OutputRequest { FromDate = fromDate, ToDate = toDate, TeamId = teamId }, cancellationToken);
@@ -95,7 +98,8 @@ namespace PVOutput.Net.Modules
         /// <returns>Aggregated outputs for the requested period.</returns>
         public Task<PVOutputArrayResponse<IAggregatedOutput>> GetAggregatedOutputsAsync(DateTime fromDate, DateTime toDate, AggregationPeriod period, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).Max(DateTime.Today);
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).IsNoFutureDate().NoTimeComponent();
+            Guard.Argument(fromDate, nameof(fromDate)).NoTimeComponent();
 
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IAggregatedOutput>(new OutputRequest { FromDate = fromDate, ToDate = toDate, Aggregation = period }, cancellationToken);

--- a/src/PVOutput.Net/Modules/OutputService.cs
+++ b/src/PVOutput.Net/Modules/OutputService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using PVOutput.Net.Enums;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Requests.Handler;
@@ -30,8 +31,9 @@ namespace PVOutput.Net.Modules
         /// <returns>Output for the requested date.</returns>
         public Task<PVOutputResponse<IOutput>> GetOutputForDateAsync(DateTime date, bool getInsolation = false, int? systemId = null, CancellationToken cancellationToken = default)
         {
-            var handler = new RequestHandler(Client);
+            Guard.Argument(date, nameof(date)).Max(DateTime.Today);
 
+            var handler = new RequestHandler(Client);
             return handler.ExecuteSingleItemRequestAsync<IOutput>(new OutputRequest { FromDate = date, ToDate = date, SystemId = systemId, Insolation = getInsolation }, cancellationToken);
         }
 
@@ -46,8 +48,9 @@ namespace PVOutput.Net.Modules
         /// <returns>Outputs for the requested period.</returns>
         public Task<PVOutputArrayResponse<IOutput>> GetOutputsForPeriodAsync(DateTime fromDate, DateTime toDate, bool getInsolation = false, int? systemId = null, CancellationToken cancellationToken = default)
         {
-            var handler = new RequestHandler(Client);
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).Max(DateTime.Today);
 
+            var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IOutput>(new OutputRequest { FromDate = fromDate, ToDate = toDate, SystemId = systemId, Insolation = getInsolation }, cancellationToken);
         }
 
@@ -60,8 +63,9 @@ namespace PVOutput.Net.Modules
         /// <returns>Team output for the requested date.</returns>
         public Task<PVOutputResponse<ITeamOutput>> GetTeamOutputForDateAsync(DateTime date, int teamId, CancellationToken cancellationToken = default)
         {
-            var handler = new RequestHandler(Client);
+            Guard.Argument(date, nameof(date)).Max(DateTime.Today);
 
+            var handler = new RequestHandler(Client);
             return handler.ExecuteSingleItemRequestAsync<ITeamOutput>(new OutputRequest { FromDate = date, ToDate = date, TeamId = teamId }, cancellationToken);
         }
 
@@ -75,8 +79,9 @@ namespace PVOutput.Net.Modules
         /// <returns>Team outputs Outputs for the requested period.</returns>
         public Task<PVOutputArrayResponse<ITeamOutput>> GetTeamOutputsForPeriodAsync(DateTime fromDate, DateTime toDate, int teamId, CancellationToken cancellationToken = default)
         {
-            var handler = new RequestHandler(Client);
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).Max(DateTime.Today);
 
+            var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<ITeamOutput>(new OutputRequest { FromDate = fromDate, ToDate = toDate, TeamId = teamId }, cancellationToken);
         }
 
@@ -90,8 +95,9 @@ namespace PVOutput.Net.Modules
         /// <returns>Aggregated outputs for the requested period.</returns>
         public Task<PVOutputArrayResponse<IAggregatedOutput>> GetAggregatedOutputsAsync(DateTime fromDate, DateTime toDate, AggregationPeriod period, CancellationToken cancellationToken = default)
         {
-            var handler = new RequestHandler(Client);
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate).Max(DateTime.Today);
 
+            var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IAggregatedOutput>(new OutputRequest { FromDate = fromDate, ToDate = toDate, Aggregation = period }, cancellationToken);
         }
 
@@ -104,6 +110,8 @@ namespace PVOutput.Net.Modules
         /// <returns>If the operation succeeded.</returns>
         public Task<PVOutputBasicResponse> AddOutputAsync(IOutputPost output, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(output, nameof(output)).NotNull();
+
             var handler = new RequestHandler(Client);
             return handler.ExecutePostRequestAsync(new AddOutputRequest() { Output = output }, cancellationToken);
         }
@@ -117,9 +125,10 @@ namespace PVOutput.Net.Modules
         /// <returns>If the operation succeeded.</returns>
         public Task<PVOutputBasicResponse> AddBatchOutputAsync(IEnumerable<IBatchOutputPost> outputs, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(outputs, nameof(outputs)).NotNull().NotEmpty();
+
             var handler = new RequestHandler(Client);
             return handler.ExecutePostRequestAsync(new AddBatchOutputRequest() { Outputs = outputs }, cancellationToken);
         }
-
     }
 }

--- a/src/PVOutput.Net/Modules/SearchService.cs
+++ b/src/PVOutput.Net/Modules/SearchService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
@@ -31,8 +32,9 @@ namespace PVOutput.Net.Modules
         /// <returns>A list of search results.</returns>
         public Task<PVOutputArrayResponse<ISystemSearchResult>> SearchAsync(string searchQuery, PVCoordinate? coordinate = null, CancellationToken cancellationToken = default)
         {
-            var handler = new RequestHandler(Client);
+            Guard.Argument(searchQuery, nameof(searchQuery)).NotEmpty().NotNull();
 
+            var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = searchQuery, Coordinate = coordinate }, cancellationToken);
         }
     }

--- a/src/PVOutput.Net/Modules/StatisticsService.cs
+++ b/src/PVOutput.Net/Modules/StatisticsService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
@@ -46,6 +47,8 @@ namespace PVOutput.Net.Modules
         /// <returns>Statistical information for the requested period.</returns>
         public Task<PVOutputResponse<IStatistic>> GetStatisticsForPeriodAsync(DateTime fromDate, DateTime toDate, bool includeConsumptionAndImport = false, bool includeCreditDebit = false, int? systemId = null, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(toDate, nameof(toDate)).GreaterThan(fromDate);
+
             var handler = new RequestHandler(Client);
             return handler.ExecuteSingleItemRequestAsync<IStatistic>(new StatisticPeriodRequest { FromDate = fromDate, ToDate = toDate, SystemId = systemId, IncludeConsumptionImport = includeConsumptionAndImport, IncludeCreditDebit = includeCreditDebit }, cancellationToken);
         }

--- a/src/PVOutput.Net/Modules/StatusService.cs
+++ b/src/PVOutput.Net/Modules/StatusService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
@@ -20,7 +21,7 @@ namespace PVOutput.Net.Modules
         }
 
         /// <summary>
-        /// Get the system status a a specific moment.
+        /// Get the system status at a specific moment.
         /// </summary>
         /// <param name="moment">Moment to retrieve the system status for.</param>
         /// <param name="systemId">Retrieve status for a specific system. <strong>Note: this is a donation only parameter.</strong></param>
@@ -28,6 +29,8 @@ namespace PVOutput.Net.Modules
         /// <returns>Status at the specified moment.</returns>
         public Task<PVOutputResponse<IStatus>> GetStatusForDateTimeAsync(DateTime moment, int? systemId = null, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(moment, nameof(moment)).LessThan(DateTime.Today.AddDays(1));
+
             var handler = new RequestHandler(Client);
             return handler.ExecuteSingleItemRequestAsync<IStatus>(new GetStatusRequest { Date = moment, SystemId = systemId }, cancellationToken);
         }
@@ -45,6 +48,8 @@ namespace PVOutput.Net.Modules
         /// <returns>Statusses for the specified period.</returns>
         public Task<PVOutputArrayResponse<IStatusHistory>> GetHistoryForPeriodAsync(DateTime fromDateTime, DateTime toDateTime, bool ascending = false, int? systemId = null, bool extendedData = false, int? limit = null, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).LessThan(DateTime.Today.AddDays(1));
+
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IStatusHistory>(
                 new GetStatusRequest { Date = fromDateTime.Date, From = fromDateTime, To = toDateTime, Ascending = ascending, SystemId = systemId, Extended = extendedData, Limit = limit, History = true }, cancellationToken);
@@ -56,10 +61,12 @@ namespace PVOutput.Net.Modules
         /// <param name="fromDateTime">Minimum datetime for the requested range.</param>
         /// <param name="toDateTime">Maximum datetime for the requested range.</param>
         /// <param name="systemId">Retrieve statuses for a specific system. <strong>Note: this is a donation only parameter.</strong></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">A cancellation token for the request.</param>
+        /// <returns>Day statistics for the specified period.</returns>
         public Task<PVOutputResponse<IDayStatistics>> GetDayStatisticsForPeriodAsync(DateTime fromDateTime, DateTime toDateTime, int? systemId = null, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).LessThan(DateTime.Today.AddDays(1));
+
             var handler = new RequestHandler(Client);
             var response = handler.ExecuteSingleItemRequestAsync<IDayStatistics>(new GetDayStatisticsRequest { Date = fromDateTime.Date, From = fromDateTime, To = toDateTime, SystemId = systemId }, cancellationToken);
 
@@ -88,6 +95,8 @@ namespace PVOutput.Net.Modules
         /// <returns>If the operation succeeded.</returns>
         public Task<PVOutputBasicResponse> AddStatusAsync(IStatusPost status, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(status, nameof(status)).NotNull();
+
             var handler = new RequestHandler(Client);
             return handler.ExecutePostRequestAsync(new AddStatusRequest() { StatusPost = status }, cancellationToken);
         }
@@ -101,6 +110,8 @@ namespace PVOutput.Net.Modules
         /// <returns>If the operation succeeded.</returns>
         public Task<PVOutputArrayResponse<IBatchStatusPostResult>> AddBatchStatusAsync(IEnumerable<IBatchStatusPost> statuses, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(statuses, nameof(statuses)).NotNull().NotEmpty();
+
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IBatchStatusPostResult>(new AddBatchStatusRequest() { StatusPosts = statuses }, cancellationToken); ;
         }
@@ -114,6 +125,8 @@ namespace PVOutput.Net.Modules
         /// <returns>If the operation succeeded.</returns>
         public Task<PVOutputBasicResponse> DeleteStatusAsync(DateTime moment, CancellationToken cancellationToken = default)
         {
+            Guard.Argument(moment, nameof(moment)).LessThan(DateTime.Today.AddDays(1));
+
             var handler = new RequestHandler(Client);
             return handler.ExecutePostRequestAsync(new DeleteStatusRequest() { Timestamp = moment }, cancellationToken);
         }

--- a/src/PVOutput.Net/Modules/StatusService.cs
+++ b/src/PVOutput.Net/Modules/StatusService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dawn;
 using PVOutput.Net.Objects;
+using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Requests.Handler;
 using PVOutput.Net.Requests.Modules;
 using PVOutput.Net.Responses;
@@ -29,7 +30,7 @@ namespace PVOutput.Net.Modules
         /// <returns>Status at the specified moment.</returns>
         public Task<PVOutputResponse<IStatus>> GetStatusForDateTimeAsync(DateTime moment, int? systemId = null, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(moment, nameof(moment)).LessThan(DateTime.Today.AddDays(1));
+            Guard.Argument(moment, nameof(moment)).IsNoFutureDate();
 
             var handler = new RequestHandler(Client);
             return handler.ExecuteSingleItemRequestAsync<IStatus>(new GetStatusRequest { Date = moment, SystemId = systemId }, cancellationToken);
@@ -48,7 +49,7 @@ namespace PVOutput.Net.Modules
         /// <returns>Statusses for the specified period.</returns>
         public Task<PVOutputArrayResponse<IStatusHistory>> GetHistoryForPeriodAsync(DateTime fromDateTime, DateTime toDateTime, bool ascending = false, int? systemId = null, bool extendedData = false, int? limit = null, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).LessThan(DateTime.Today.AddDays(1));
+            Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).IsNoFutureDate();
 
             var handler = new RequestHandler(Client);
             return handler.ExecuteArrayRequestAsync<IStatusHistory>(
@@ -65,7 +66,7 @@ namespace PVOutput.Net.Modules
         /// <returns>Day statistics for the specified period.</returns>
         public Task<PVOutputResponse<IDayStatistics>> GetDayStatisticsForPeriodAsync(DateTime fromDateTime, DateTime toDateTime, int? systemId = null, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).LessThan(DateTime.Today.AddDays(1));
+            Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).IsNoFutureDate();
 
             var handler = new RequestHandler(Client);
             var response = handler.ExecuteSingleItemRequestAsync<IDayStatistics>(new GetDayStatisticsRequest { Date = fromDateTime.Date, From = fromDateTime, To = toDateTime, SystemId = systemId }, cancellationToken);
@@ -125,7 +126,7 @@ namespace PVOutput.Net.Modules
         /// <returns>If the operation succeeded.</returns>
         public Task<PVOutputBasicResponse> DeleteStatusAsync(DateTime moment, CancellationToken cancellationToken = default)
         {
-            Guard.Argument(moment, nameof(moment)).LessThan(DateTime.Today.AddDays(1));
+            Guard.Argument(moment, nameof(moment)).IsNoFutureDate();
 
             var handler = new RequestHandler(Client);
             return handler.ExecutePostRequestAsync(new DeleteStatusRequest() { Timestamp = moment }, cancellationToken);

--- a/src/PVOutput.Net/Modules/SupplyService.cs
+++ b/src/PVOutput.Net/Modules/SupplyService.cs
@@ -31,9 +31,7 @@ namespace PVOutput.Net.Modules
         public Task<PVOutputArrayResponse<ISupply>> GetSupplyAsync(string timeZone = null, string regionKey = null, CancellationToken cancellationToken = default)
         {
             var handler = new RequestHandler(Client);
-
-            return handler.ExecuteArrayRequestAsync<ISupply>(
-                new SupplyRequest { TimeZone = timeZone, RegionKey = regionKey }, cancellationToken);
+            return handler.ExecuteArrayRequestAsync<ISupply>(new SupplyRequest { TimeZone = timeZone, RegionKey = regionKey }, cancellationToken);
         }
     }
 }

--- a/src/PVOutput.Net/Modules/SystemService.cs
+++ b/src/PVOutput.Net/Modules/SystemService.cs
@@ -25,7 +25,6 @@ namespace PVOutput.Net.Modules
         public Task<PVOutputResponse<ISystem>> GetOwnSystemAsync(CancellationToken cancellationToken = default)
         {
             var handler = new RequestHandler(Client);
-
             return handler.ExecuteSingleItemRequestAsync<ISystem>(new SystemRequest(), cancellationToken);
         }
 
@@ -39,7 +38,6 @@ namespace PVOutput.Net.Modules
         public Task<PVOutputResponse<ISystem>> GetOtherSystemAsync(int systemId, CancellationToken cancellationToken = default)
         {
             var handler = new RequestHandler(Client);
-
             return handler.ExecuteSingleItemRequestAsync<ISystem>(new SystemRequest { SystemId = systemId, MonthlyEstimates = false }, cancellationToken);
         }
     }

--- a/src/PVOutput.Net/Objects/Core/GuardExtensions.cs
+++ b/src/PVOutput.Net/Objects/Core/GuardExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Dawn;
+
+namespace PVOutput.Net.Objects.Core
+{
+    internal static class GuardExtensions
+    {
+        internal static Guard.ArgumentInfo<DateTime> IsNoFutureDate(this Guard.ArgumentInfo<DateTime> argument)
+        {
+            return argument.LessThan(DateTime.Today.AddDays(1));
+        }
+
+        public static ref readonly Guard.ArgumentInfo<DateTime> NoTimeComponent(in this Guard.ArgumentInfo<DateTime> argument)
+        {
+            if (argument.Value.TimeOfDay != TimeSpan.Zero)
+            {
+                throw Guard.Fail(new ArgumentException(
+                    $"{argument.Name} has a time component." +
+                    "Please only use DateTime.Date instead.",
+                    argument.Name));
+            }
+
+            return ref argument;
+        }
+    }
+}

--- a/src/PVOutput.Net/Objects/ExtendedDataConfiguration.cs
+++ b/src/PVOutput.Net/Objects/ExtendedDataConfiguration.cs
@@ -6,7 +6,7 @@ namespace PVOutput.Net.Objects
     /// <summary>
     /// Element describing a configured extended data value
     /// </summary>
-    public struct ExtendedDataConfiguration : IEquatable<ExtendedDataConfiguration>
+    public readonly struct ExtendedDataConfiguration : IEquatable<ExtendedDataConfiguration>
     {
         /// <summary>The label that the extended value has</summary>
         public string Label { get; }

--- a/src/PVOutput.Net/Objects/OutputPostBuilder.cs
+++ b/src/PVOutput.Net/Objects/OutputPostBuilder.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Resources;
 using System.Text;
+using Dawn;
 using PVOutput.Net.Enums;
+using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Implementations;
 
@@ -31,6 +33,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetDate(DateTime date)
         {
+            Guard.Argument(date, nameof(date)).IsNoFutureDate().NoTimeComponent();
+
             _outputPost.OutputDate = date;
             return this;
         }
@@ -98,6 +102,13 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetTemperatures(decimal? minimumTemperature, decimal? maximumTemperature)
         {
+            Guard.NotAllNull(Guard.Argument(minimumTemperature, nameof(minimumTemperature)), Guard.Argument(maximumTemperature, nameof(maximumTemperature)));
+
+            if (minimumTemperature.HasValue && maximumTemperature.HasValue)
+            {
+                Guard.Argument(maximumTemperature.Value, nameof(maximumTemperature)).GreaterThan(minimumTemperature.Value);
+            }
+
             _outputPost.MinimumTemperature = minimumTemperature;
             _outputPost.MaximumTemperature = maximumTemperature;
             return this;
@@ -110,6 +121,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetComments(string comments)
         {
+            Guard.Argument(comments, nameof(comments)).NotEmpty().NotNull();
+
             _outputPost.Comments = comments;
             return this;
         }

--- a/src/PVOutput.Net/Objects/OutputPostBuilder.cs
+++ b/src/PVOutput.Net/Objects/OutputPostBuilder.cs
@@ -46,6 +46,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetGenerated(int energyGenerated)
         {
+            Guard.Argument(energyGenerated, nameof(energyGenerated)).Min(0);
+
             _outputPost.EnergyGenerated = energyGenerated;
             return this;
         }
@@ -57,6 +59,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetExported(int energyExported)
         {
+            Guard.Argument(energyExported, nameof(energyExported)).Min(0);
+
             _outputPost.EnergyExported = energyExported;
             return this;
         }
@@ -79,6 +83,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetPeakPower(int peakPower)
         {
+            Guard.Argument(peakPower, nameof(peakPower)).Min(0);
+
             _outputPost.PeakPower = peakPower;
             return this;
         }
@@ -134,6 +140,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetPeakEnergyImport(int peakImport)
         {
+            Guard.Argument(peakImport, nameof(peakImport)).Min(0);
+
             _outputPost.PeakEnergyImport = peakImport;
             return this;
         }
@@ -145,6 +153,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetOffPeakEnergyImport(int offpeakImport)
         {
+            Guard.Argument(offpeakImport, nameof(offpeakImport)).Min(0);
+
             _outputPost.OffPeakEnergyImport = offpeakImport;
             return this;
         }
@@ -156,6 +166,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetShoulderEnergyImport(int shoulderImport)
         {
+            Guard.Argument(shoulderImport, nameof(shoulderImport)).Min(0);
+
             _outputPost.ShoulderEnergyImport = shoulderImport;
             return this;
         }
@@ -167,6 +179,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public OutputPostBuilder<TResultType> SetHighShoulderEnergyImport(int highShoulderImport)
         {
+            Guard.Argument(highShoulderImport, nameof(highShoulderImport)).Min(0);
+
             _outputPost.HighShoulderEnergyImport = highShoulderImport;
             return this;
         }
@@ -179,6 +193,8 @@ namespace PVOutput.Net.Objects
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Exception messages are non translatable for now")]
         public OutputPostBuilder<TResultType> SetConsumption(int consumption)
         {
+            Guard.Argument(consumption, nameof(consumption)).Min(0);
+
             if (typeof(TResultType) == typeof(IBatchOutputPost))
             {
                 throw new InvalidOperationException("Cannot set consumption for batch output");

--- a/src/PVOutput.Net/Objects/PVCoordinate.cs
+++ b/src/PVOutput.Net/Objects/PVCoordinate.cs
@@ -8,7 +8,7 @@ namespace PVOutput.Net.Objects
     /// <summary>
     /// Describes a location using a Latitude and Longitude.
     /// </summary>
-    public struct PVCoordinate : IEquatable<PVCoordinate>
+    public readonly struct PVCoordinate : IEquatable<PVCoordinate>
     {
         /// <summary>
         /// Latitudinal part of the coordinate. 

--- a/src/PVOutput.Net/Objects/StatusPostBuilder.cs
+++ b/src/PVOutput.Net/Objects/StatusPostBuilder.cs
@@ -47,6 +47,9 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public StatusPostBuilder<TResultType> SetGeneration(int? energyGeneration, int? powerGeneration)
         {
+            Guard.Argument(energyGeneration, nameof(energyGeneration)).Min(0);
+            Guard.Argument(powerGeneration, nameof(powerGeneration)).Min(0);
+
             _statusPost.EnergyGeneration = energyGeneration;
             _statusPost.PowerGeneration = powerGeneration;
             return this;
@@ -60,6 +63,9 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public StatusPostBuilder<TResultType> SetConsumption(int? energyConsumption, int? powerConsumption)
         {
+            Guard.Argument(energyConsumption, nameof(energyConsumption)).Min(0);
+            Guard.Argument(powerConsumption, nameof(powerConsumption)).Min(0);
+
             _statusPost.EnergyConsumption = energyConsumption;
             _statusPost.PowerConsumption = powerConsumption;
             return this;
@@ -83,6 +89,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public StatusPostBuilder<TResultType> SetVoltage(decimal voltage)
         {
+            Guard.Argument(voltage, nameof(voltage)).InRange(0, 300);
+
             _statusPost.Voltage = voltage;
             return this;
         }

--- a/src/PVOutput.Net/Objects/StatusPostBuilder.cs
+++ b/src/PVOutput.Net/Objects/StatusPostBuilder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Dawn;
 using PVOutput.Net.Enums;
+using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Implementations;
 
@@ -30,6 +32,8 @@ namespace PVOutput.Net.Objects
         /// <returns>The builder.</returns>
         public StatusPostBuilder<TResultType> SetTimeStamp(DateTime timestamp)
         {
+            Guard.Argument(timestamp, nameof(timestamp)).IsNoFutureDate();
+            
             _statusPost.Timestamp = timestamp;
             return this;
         
@@ -134,10 +138,7 @@ namespace PVOutput.Net.Objects
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Exception messages are non translatable for now")]
         public StatusPostBuilder<TResultType> SetTextMessage(string textMessage)
         {
-            if (textMessage?.Length > 30)
-            {
-                throw new ArgumentException("Length cannot be longer than 30 characters", nameof(textMessage));
-            }
+            Guard.Argument(textMessage, nameof(textMessage)).NotEmpty().LengthInRange(1, 30);
 
             _statusPost.TextMessage = textMessage;
             return this;

--- a/src/PVOutput.Net/PVOutput.Net.csproj
+++ b/src/PVOutput.Net/PVOutput.Net.csproj
@@ -25,6 +25,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\..\artifacts\</OutputPath>
     <DocumentationFile>..\..\artifacts\$(AssemblyName).xml</DocumentationFile>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/PVOutput.Net/PVOutput.Net.csproj
+++ b/src/PVOutput.Net/PVOutput.Net.csproj
@@ -32,6 +32,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\artifacts\release\</OutputPath>
     <DocumentationFile>..\..\artifacts\release\$(AssemblyName).xml</DocumentationFile>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PVOutput.Net/PVOutput.Net.csproj
+++ b/src/PVOutput.Net/PVOutput.Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Marcel Boersma</Authors>
@@ -33,6 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dawn.Guard" Version="1.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/PVOutput.Net.Tests/Modules/Extended/ExtendedServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Extended/ExtendedServiceTests.cs
@@ -54,6 +54,28 @@ namespace PVOutput.Net.Tests.Modules.Extended
             AssertStandardResponse(response);
         }
 
+        [Test]
+        public void ExtendedService_GetExtendedDataForPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Extended.GetExtendedDataForPeriodAsync(new DateTime(2016, 3, 7), new DateTime(2016, 3, 6));
+            });
+        }
+
+        [Test]
+        public void ExtendedService_GetExtendedDataForPeriod_WithLimitThatIsTooHigh_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Extended.GetExtendedDataForPeriodAsync(DateTime.Today.AddDays(-1), DateTime.Today, 100);
+            });
+        }
+
         /*
          * Deserialisation tests below
          */

--- a/tests/PVOutput.Net.Tests/Modules/Missing/MissingServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Missing/MissingServiceTests.cs
@@ -26,6 +26,17 @@ namespace PVOutput.Net.Tests.Modules.Missing
             AssertStandardResponse(response);
         }
 
+        [Test]
+        public void MissingService_GetMissingDaysInPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Missing.GetMissingDaysInPeriodAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29));
+            });
+        }
+
         /*
          * Deserialisation tests below
          */

--- a/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
@@ -44,12 +44,31 @@ namespace PVOutput.Net.Tests.Modules.Output
         }
 
         [Test]
+        public void OutputPostBuilder_WithNegativeGeneration_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetGenerated(-1);
+            });
+        }
+
+        [Test]
         public void OutputPostBuilder_WithExported_SetsExported()
         {
             var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today)
                 .SetExported(12121);
 
             Assert.AreEqual(12121, builder._outputPost.EnergyExported);
+        }
+
+
+        [Test]
+        public void OutputPostBuilder_WithNegativeExported_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetExported(-1);
+            });
         }
 
         [Test]
@@ -81,6 +100,15 @@ namespace PVOutput.Net.Tests.Modules.Output
                 .SetPeakPower(13131);
 
             Assert.AreEqual(13131, builder._outputPost.PeakPower);
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithNegativePeakPower_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetPeakPower(-1);
+            });
         }
 
         [Test]
@@ -170,12 +198,30 @@ namespace PVOutput.Net.Tests.Modules.Output
         }
 
         [Test]
+        public void OutputPostBuilder_WithNegativePeakEnergyImport_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetPeakEnergyImport(-1);
+            });
+        }
+
+        [Test]
         public void OutputPostBuilder_WithOffPeakImport_SetsOffPeakEnergyImport()
         {
             var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today)
                 .SetOffPeakEnergyImport(13131);
 
             Assert.AreEqual(13131, builder._outputPost.OffPeakEnergyImport);
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithNegativeOffPeakEnergyImport_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetOffPeakEnergyImport(-1);
+            });
         }
 
         [Test]
@@ -188,6 +234,15 @@ namespace PVOutput.Net.Tests.Modules.Output
         }
 
         [Test]
+        public void OutputPostBuilder_WithNegativeShoulderEnergyImport_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetShoulderEnergyImport(-1);
+            });
+        }
+
+        [Test]
         public void OutputPostBuilder_WithHighShoulderEnergyImport_SetHighShoulderEnergyImport()
         {
             var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today)
@@ -197,12 +252,30 @@ namespace PVOutput.Net.Tests.Modules.Output
         }
 
         [Test]
+        public void OutputPostBuilder_WithNegativeHighShoulderEnergyImport_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetHighShoulderEnergyImport(-1);
+            });
+        }
+
+        [Test]
         public void OutputPostBuilder_WithConsumption_SetConsumption()
         {
             var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today)
                 .SetConsumption(25000);
 
             Assert.AreEqual(25000, builder._outputPost.Consumption);
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithNegativeConsumption_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetConsumption(-1);
+            });
         }
 
         [Test]

--- a/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
@@ -26,6 +26,15 @@ namespace PVOutput.Net.Tests.Modules.Output
         }
 
         [Test]
+        public void OutputPostBuilder_WithTimeComponent_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => 
+            {
+                _ = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today.AddMinutes(10));
+            });
+        }
+
+        [Test]
         public void OutputPostBuilder_WithGeneration_SetsGeneration()
         { 
             var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today)
@@ -98,6 +107,28 @@ namespace PVOutput.Net.Tests.Modules.Output
         }
 
         [Test]
+        public void OutputPostBuilder_WithReversedTemperatures_Throws()
+        {
+            var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                builder.SetTemperatures(15, 10);
+            });
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithBothNullTemperatures_Throws()
+        {
+            var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today);
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                builder.SetTemperatures(null, null);
+            });
+        }
+
+        [Test]
         public void OutputPostBuilder_WithComment_SetsComment()
         {
             const string testComment = "This is a comment";
@@ -105,6 +136,28 @@ namespace PVOutput.Net.Tests.Modules.Output
                 .SetComments(testComment);
 
             Assert.AreEqual(testComment, builder._outputPost.Comments);
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithEmptyComment_Throws()
+        {
+            var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                builder.SetComments("");
+            });
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithNullComment_Throws()
+        {
+            var builder = new OutputPostBuilder<IOutputPost>().SetDate(DateTime.Today);
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                builder.SetComments(null);
+            });
         }
 
         [Test]

--- a/tests/PVOutput.Net.Tests/Modules/Output/OutputServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/OutputServiceTests.cs
@@ -123,9 +123,130 @@ namespace PVOutput.Net.Tests.Modules.Output
             AssertStandardResponse(response);
         }
 
+        [Test]
+        public void OutputService_GetOutputForDate_WithFutureDate_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetOutputForDateAsync(DateTime.Today.AddDays(1));
+            });
+        }
+
+        [Test]
+        public void OutputService_GetOutputsForPeriod_WithFutureRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetOutputsForPeriodAsync(DateTime.Today, DateTime.Today.AddDays(1));
+            });
+        }
+
+        [Test]
+        public void OutputService_GetOutputsForPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetOutputsForPeriodAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29));
+            });
+        }
+
+        [Test]
+        public void OutputService_GetTeamOutputForDate_WithFutureDate_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetTeamOutputForDateAsync(DateTime.Today.AddDays(1), 1234);
+            });
+        }
+
+        [Test]
+        public void OutputService_GetTeamOutputsForPeriod_WithFutureRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetTeamOutputsForPeriodAsync(DateTime.Today, DateTime.Today.AddDays(1), 1234);
+            });
+        }
+
+        [Test]
+        public void OutputService_GetTeamOutputsForPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetTeamOutputsForPeriodAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29), 1234);
+            });
+        }
+
+        [Test]
+        public void OutputService_GetAggregatedOutputs_WithFutureRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetAggregatedOutputsAsync(DateTime.Today, DateTime.Today.AddDays(1), AggregationPeriod.Month);
+            });
+        }
+
+        [Test]
+        public void OutputService_GetAggregatedOutputs_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Output.GetAggregatedOutputsAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29), AggregationPeriod.Month);
+            });
+        }
+
         /* 
             Adding outputs
         */
+
+        [Test]
+        public void OutputService_AddOutput_WithNullOutput_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                _ = await client.Output.AddOutputAsync(null);
+            });
+        }
+
+        [Test]
+        public void OutputService_AddBatchOutput_WithNullOutputs_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                _ = await client.Output.AddBatchOutputAsync(null);
+            });
+        }
+
+        [Test]
+        public void OutputService_AddBatchOutput_WithEmptyOutputs_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                _ = await client.Output.AddBatchOutputAsync(new List<IBatchOutputPost>());
+            });
+        }
 
         public static IEnumerable AddOutputTestCases
         {

--- a/tests/PVOutput.Net.Tests/Modules/Search/SearchServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Search/SearchServiceTests.cs
@@ -17,16 +17,41 @@ namespace PVOutput.Net.Tests.Modules.Search
     public partial class SearchServiceTests : BaseRequestsTest
     {
         [Test]
-        public async Task SearchService_WithNoParameters_CallsCorrectUri()
+        public async Task SearchService_WithQuery_CallsCorrectUri()
         {
             PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
             testProvider.ExpectUriFromBase(SEARCH_URL)
                         .RespondPlainText("");
 
-            var response = await client.Search.SearchAsync("");
+            var response = await client.Search.SearchAsync("test query");
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
         }
+
+
+        [Test]
+        public void SearchService_Search_WithNullOrEmptyQuery_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                _ = await client.Search.SearchAsync(null);
+            });
+        }
+
+
+        [Test]
+        public void SearchService_Search_WithEmptyQuery_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                _ = await client.Search.SearchAsync("");
+            });
+        }
+
 
         /*
          * Deserialisation tests below

--- a/tests/PVOutput.Net.Tests/Modules/Statistic/StatisticServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Statistic/StatisticServiceTests.cs
@@ -39,6 +39,17 @@ namespace PVOutput.Net.Tests.Modules.Statistic
             AssertStandardResponse(response);
         }
 
+        [Test]
+        public void StatisticsService_GetStatisticsForPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Statistics.GetStatisticsForPeriodAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29));
+            });
+        }
+
         /*
          * Deserialisation tests below
          */

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusBuilderTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusBuilderTests.cs
@@ -51,6 +51,17 @@ namespace PVOutput.Net.Tests.Modules.Status
         }
 
         [Test]
+        [TestCase(new object[] { null, -1 })]
+        [TestCase(new object[] { -1, null })]
+        public void StatusPostBuilder_WithNegativeGeneration_Throws(int? energyGeneration, int? powerGeneration)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new StatusPostBuilder<IStatusPost>().SetGeneration(energyGeneration, powerGeneration);
+            });
+        }
+
+        [Test]
         [TestCase(new object[] { 10, 20 })]
         [TestCase(new object[] { null, 30 })]
         [TestCase(new object[] { 15, null })]
@@ -60,6 +71,17 @@ namespace PVOutput.Net.Tests.Modules.Status
 
             Assert.AreEqual(energyConsumption, builder._statusPost.EnergyConsumption);
             Assert.AreEqual(powerConsumption, builder._statusPost.PowerConsumption);
+        }
+
+        [Test]
+        [TestCase(new object[] { null, -1 })]
+        [TestCase(new object[] { -1, null })]
+        public void StatusPostBuilder_WithNegativeConsumption_Throws(int? energyConsumption, int? powerConsumption)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new StatusPostBuilder<IStatusPost>().SetConsumption(energyConsumption, powerConsumption);
+            });
         }
 
         [Test]
@@ -76,6 +98,17 @@ namespace PVOutput.Net.Tests.Modules.Status
             var builder = new StatusPostBuilder<IStatusPost>().SetVoltage(231.2m);
 
             Assert.AreEqual(231.2m, builder._statusPost.Voltage);
+        }
+
+        [Test]
+        [TestCase(-1)]
+        [TestCase(301)]
+        public void StatusPostBuilder_WithVoltageOutOfRange_Throws(decimal voltage)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _ = new StatusPostBuilder<IStatusPost>().SetVoltage(voltage);
+            });
         }
 
         [Test]

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusBuilderTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusBuilderTests.cs
@@ -27,6 +27,18 @@ namespace PVOutput.Net.Tests.Modules.Status
         }
 
         [Test]
+        public void StatusPostBuilder_WithFutureTimeStamp_Throws()
+        {
+            var timeStamp = DateTime.Now.AddDays(1);
+            var builder = new StatusPostBuilder<IStatusPost>();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                builder.SetTimeStamp(timeStamp);
+            });
+        }
+
+        [Test]
         [TestCase(new object[] { 10, 20 })]
         [TestCase(new object[] { null, 30 })]
         [TestCase(new object[] { 15, null })]
@@ -114,9 +126,11 @@ namespace PVOutput.Net.Tests.Modules.Status
         [Test]
         public void StatusPostBuilder_WithTooLongTextMessage_Throws()
         {
-            var exception = Assert.Throws<ArgumentException>(() =>
+            var builder = new StatusPostBuilder<IStatusPost>();
+
+            Assert.Throws<ArgumentException>(() =>
             {
-                var builder = new StatusPostBuilder<IStatusPost>().SetTextMessage("0123456789001234567890012345678901");
+                builder.SetTextMessage("0123456789001234567890012345678901");
             });
         }
 
@@ -145,6 +159,7 @@ namespace PVOutput.Net.Tests.Modules.Status
         public void StatusPostBuilder_WithoutPowerOrConsumption_CannotBuild()
         {
             var builder = new StatusPostBuilder<IStatusPost>().SetTextMessage("Test");
+
             Assert.Throws<InvalidOperationException>(() =>
             {
                 builder.Build();

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
@@ -59,6 +59,108 @@ namespace PVOutput.Net.Tests.Modules.Status
             Assert.AreEqual(new DateTime(2020, 1, 31, 15, 5, 0), response.Value.StandbyPowerTime);
         }
 
+        [Test]
+        public void StatusService_GetStatusForDateTime_WithFutureDate_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Status.GetStatusForDateTimeAsync(DateTime.Today.AddDays(1));
+            });
+        }
+
+        [Test]
+        public void StatusService_DeleteStatus_WithFutureDate_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Status.DeleteStatusAsync(DateTime.Today.AddDays(1));
+            });
+        }
+
+
+        [Test]
+        public void StatusService_GetHistoryForPeriod_WithFutureRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Status.GetHistoryForPeriodAsync(DateTime.Today, DateTime.Today.AddDays(1));
+            });
+        }
+
+        [Test]
+        public void StatusService_GetHistoryForPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Status.GetHistoryForPeriodAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29));
+            });
+        }
+
+        [Test]
+        public void StatusService_GetDayStatisticsForPeriod_WithFutureRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Status.GetDayStatisticsForPeriodAsync(DateTime.Today, DateTime.Today.AddDays(1));
+            });
+        }
+
+        [Test]
+        public void StatusService_GetDayStatisticsForPeriod_WithReversedRange_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                _ = await client.Status.GetDayStatisticsForPeriodAsync(new DateTime(2016, 8, 30), new DateTime(2016, 8, 29));
+            });
+        }
+
+
+        [Test]
+        public void StatusService_AddStatus_WithNullStatus_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                _ = await client.Status.AddStatusAsync(null);
+            });
+        }
+
+        [Test]
+        public void StatusService_AddBatchStatus_WithNullStatuses_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                _ = await client.Status.AddBatchStatusAsync(null);
+            });
+        }
+
+        [Test]
+        public void StatusService_AddBatchStatus_WithEmptyStatuses_Throws()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                _ = await client.Status.AddBatchStatusAsync(new List<IBatchStatusPost>());
+            });
+        }
+
+
         /*
          * Deserialisation tests below
          */

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
@@ -51,7 +51,7 @@ namespace PVOutput.Net.Tests.Modules.Status
                         .WithQueryString("d=20200131&from=10:00&to=16:00&stats=1")
                         .RespondPlainText(STATUS_RESPONSE_DAYSTATISTICS_MEDIUM);
 
-            var response = await client.Status.GetDayStatisticsForPeriodAsync(new DateTime(2020, 1, 31, 10, 0, 0), new DateTime(2019, 1, 31, 16, 0, 0));
+            var response = await client.Status.GetDayStatisticsForPeriodAsync(new DateTime(2020, 1, 31, 10, 0, 0), new DateTime(2020, 1, 31, 16, 0, 0));
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
 

--- a/tests/PVOutput.Net.Tests/PVOutput.Net.Tests.csproj
+++ b/tests/PVOutput.Net.Tests/PVOutput.Net.Tests.csproj
@@ -6,6 +6,10 @@
     <OutputPath>..\..\artifacts\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1">


### PR DESCRIPTION
Using Dawn.Guard, add argument validation to all public api methods. Goal is to prevent - for as far as possible - incorrect calls to the PVOutput.org api with uncertain results.

This will include guards on future dates or using time components to dates that are only supposed to have a date part to them. It should make working with the library safer and prevent complex exceptions from the inner parts.

Close #18 