### PR TITLE
Representing Time properties as TimeSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed bugs with encoding of text parameters `Comments` and `TextMessage` in `OutputPost` and `StatusPost` requests respectively. [#29](https://github.com/pyrocumulus/pvoutput.net/issues/29)
 - Fixed bug with `BatchOutputPostBuilder` accepting an output without both `EnergyGenerated` as wel as `EnergyUsed`. [#29](https://github.com/pyrocumulus/pvoutput.net/issues/29)
 - Breaking - renamed multiple operations on the new `OutputPostBuilders` to accurately map to the corresponding property on IOutputPost etc. [#29](https://github.com/pyrocumulus/pvoutput.net/issues/29)
-- Added structured search methods to the SearchService [#27](https://github.com/pyrocumulus/pvoutput.net/issues/27)
-- Fixed a bug with the SearchService not properly encoding the query text [#27](https://github.com/pyrocumulus/pvoutput.net/issues/27)
-- Breaking - all properties respresenting a time are now respresented as `TimeSpan` objects instead of `DateTime`. [PRHERE]
-
+- Added structured search methods to the SearchService. [#27](https://github.com/pyrocumulus/pvoutput.net/issues/27)
+- Fixed a bug with the SearchService not properly encoding the query text. [#27](https://github.com/pyrocumulus/pvoutput.net/issues/27)
+- Breaking - all properties respresenting a time are now respresented as `TimeSpan` objects instead of `DateTime`. [#30](https://github.com/pyrocumulus/pvoutput.net/issues/30)
+- Breaking - `PVCoordinate` now uses the `decimal` type for storing the `Latitude` and `Longitude` properties, to avoid weird approximation issues. [#30](https://github.com/pyrocumulus/pvoutput.net/issues/30)
 
 ## [0.6.0] - 2020-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Breaking - renamed multiple operations on the new `OutputPostBuilders` to accurately map to the corresponding property on IOutputPost etc. [#29](https://github.com/pyrocumulus/pvoutput.net/issues/29)
 - Added structured search methods to the SearchService [#27](https://github.com/pyrocumulus/pvoutput.net/issues/27)
 - Fixed a bug with the SearchService not properly encoding the query text [#27](https://github.com/pyrocumulus/pvoutput.net/issues/27)
+- Breaking - all properties respresenting a time are now respresented as `TimeSpan` objects instead of `DateTime`. [PRHERE]
 
 
 ## [0.6.0] - 2020-03-28

--- a/src/PVOutput.Net/Builders/BaseOutputPostBuilder.cs
+++ b/src/PVOutput.Net/Builders/BaseOutputPostBuilder.cs
@@ -57,9 +57,21 @@ namespace PVOutput.Net.Builders
         /// <summary>
         /// Sets the time at which peak power was recorded.
         /// </summary>
-        /// <param name="peakTime">Peak time.</param>
+        /// <param name="hours">Hour-component of the peak time.</param>
+        /// <param name="minutes">Minute-component of the peak time.</param>
         /// <returns>The builder.</returns>
-        public TBuilderType SetPeakTime(DateTime peakTime)
+        public TBuilderType SetPeakTime(int hours, int minutes)
+        {
+            OutputPost.PeakTime = new TimeSpan(hours, minutes, 0);
+            return this as TBuilderType;
+        }
+
+        /// <summary>
+        /// Sets the time at which peak power was recorded.
+        /// </summary>
+        /// <param name="peakTime">The peak time.</param>
+        /// <returns>The builder.</returns>
+        public TBuilderType SetPeakTime(TimeSpan peakTime)
         {
             OutputPost.PeakTime = peakTime;
             return this as TBuilderType;
@@ -197,11 +209,6 @@ namespace PVOutput.Net.Builders
             if (OutputPost.OutputDate == DateTime.MinValue)
             {
                 throw new InvalidOperationException("Output has no date");
-            }
-
-            if (OutputPost.PeakTime.HasValue && !OutputPost.OutputDate.Date.Equals(OutputPost.PeakTime.Value.Date))
-            {
-                throw new InvalidOperationException($"Peaktime registered on different date ({OutputPost.PeakTime.Value.ToShortDateString()}) than output itself ({OutputPost.OutputDate.ToShortDateString()})");
             }
         }
     }

--- a/src/PVOutput.Net/Modules/InsolationService.cs
+++ b/src/PVOutput.Net/Modules/InsolationService.cs
@@ -40,11 +40,6 @@ namespace PVOutput.Net.Modules
 
             var handler = new RequestHandler(Client);
             var response = handler.ExecuteArrayRequestAsync<IInsolation>(new InsolationRequest { Date = date }, loggingScope, cancellationToken);
-
-            if (date.HasValue)
-            {
-                return response.ContinueWith(antecedent => AddRequestedDate(antecedent, date.Value), cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
-            }
             return response;
         }
 
@@ -67,11 +62,6 @@ namespace PVOutput.Net.Modules
 
             var handler = new RequestHandler(Client);
             var response = handler.ExecuteArrayRequestAsync<IInsolation>(new InsolationRequest { SystemId = systemId, Date = date }, loggingScope, cancellationToken);
-
-            if (date.HasValue)
-            {
-                return response.ContinueWith(antecedent => AddRequestedDate(antecedent, date.Value), cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
-            }
             return response;
         }
 
@@ -94,21 +84,7 @@ namespace PVOutput.Net.Modules
 
             var handler = new RequestHandler(Client);
             var response = handler.ExecuteArrayRequestAsync<IInsolation>(new InsolationRequest { Coordinate = coordinate, Date = date }, loggingScope, cancellationToken);
-
-            if (date.HasValue)
-            {
-                return response.ContinueWith(antecedent => AddRequestedDate(antecedent, date.Value), cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
-            }
             return response;
-        }
-
-        private static PVOutputArrayResponse<IInsolation> AddRequestedDate(Task<PVOutputArrayResponse<IInsolation>> response, DateTime requestedDate)
-        {
-            foreach (var insolation in response.Result.Values)
-            {
-                insolation.Time = requestedDate.Add(insolation.Time.TimeOfDay);
-            }
-            return response.Result;
         }
     }
 }

--- a/src/PVOutput.Net/Modules/SearchService.cs
+++ b/src/PVOutput.Net/Modules/SearchService.cs
@@ -72,26 +72,27 @@ namespace PVOutput.Net.Modules
             return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = query }, loggingScope, cancellationToken);
         }
 
+        /*
         /// <summary>
         /// Search for systems that have either a postcode or total size that begins with a value.
         /// </summary>
         /// <param name="value">Value to search for.</param>
         /// <param name="cancellationToken">A cancellation token for the request.</param>
         /// <returns>A list of search results.</returns>
-        //public Task<PVOutputArrayResponse<ISystemSearchResult>> SearchByPostcodeOrSizeAsync(int value, CancellationToken cancellationToken = default)
-        //{
-        //    var loggingScope = new Dictionary<string, object>()
-        //    {
-        //        [LoggingEvents.RequestId] = LoggingEvents.SearchService_SearchByPostCodeOrSize,
-        //        [LoggingEvents.Parameter_Search_Value] = value
-        //    };
+        public Task<PVOutputArrayResponse<ISystemSearchResult>> SearchByPostcodeOrSizeAsync(int value, CancellationToken cancellationToken = default)
+        {
+            var loggingScope = new Dictionary<string, object>()
+            {
+                [LoggingEvents.RequestId] = LoggingEvents.SearchService_SearchByPostCodeOrSize,
+                [LoggingEvents.Parameter_Search_Value] = value
+            };
 
-        //    Guard.Argument(value, nameof(value)).GreaterThan(0);
-        //    string query = value.ToString("#####", CultureInfo.InvariantCulture);
+            Guard.Argument(value, nameof(value)).GreaterThan(0);
+            string query = value.ToString("#####", CultureInfo.InvariantCulture);
 
-        //    var handler = new RequestHandler(Client);
-        //    return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = query }, loggingScope, cancellationToken);
-        //}
+            var handler = new RequestHandler(Client);
+            return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = query }, loggingScope, cancellationToken);
+        }*/
 
         /// <summary>
         /// Search for systems by postcode.

--- a/src/PVOutput.Net/Modules/StatusService.cs
+++ b/src/PVOutput.Net/Modules/StatusService.cs
@@ -95,22 +95,7 @@ namespace PVOutput.Net.Modules
             Guard.Argument(toDateTime, nameof(toDateTime)).GreaterThan(fromDateTime).IsNoFutureDate();
 
             var handler = new RequestHandler(Client);
-            var response = handler.ExecuteSingleItemRequestAsync<IDayStatistics>(new GetDayStatisticsRequest { Date = fromDateTime.Date, From = fromDateTime, To = toDateTime, SystemId = systemId }, loggingScope, cancellationToken);
-
-            return response.ContinueWith(antecedent => AddRequestedDate(antecedent, fromDateTime.Date), cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
-        }
-
-        private static PVOutputResponse<IDayStatistics> AddRequestedDate(Task<PVOutputResponse<IDayStatistics>> response, DateTime requestedDate)
-        {
-            IDayStatistics statistics = response.Result.Value;
-            statistics.PeakTime = requestedDate.Add(statistics.PeakTime.TimeOfDay);
-
-            if (statistics.StandbyPowerTime != null)
-            {
-                statistics.StandbyPowerTime = requestedDate.Add(statistics.StandbyPowerTime.Value.TimeOfDay);
-            }
-
-            return response.Result;
+            return handler.ExecuteSingleItemRequestAsync<IDayStatistics>(new GetDayStatisticsRequest { Date = fromDateTime.Date, From = fromDateTime, To = toDateTime, SystemId = systemId }, loggingScope, cancellationToken);
         }
 
         /// <summary>

--- a/src/PVOutput.Net/Objects/Core/FormatHelper.cs
+++ b/src/PVOutput.Net/Objects/Core/FormatHelper.cs
@@ -37,19 +37,6 @@ namespace PVOutput.Net.Objects.Core
             return date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         }
 
-        internal static string GetLocationAsString(double? latitude, double? longitude)
-        {
-            if (latitude == null || longitude == null)
-            {
-                return null;
-            }
-
-            var lat = latitude.Value.ToString("##.####", CultureInfo.CreateSpecificCulture("en-US"));
-            var lon = longitude.Value.ToString("##.####", CultureInfo.CreateSpecificCulture("en-US"));
-
-            return $"{lat},{lon}";
-        }
-
         internal static string GetTimeAsString(DateTime date)
         {
             return date.ToString("HH:mm", CultureInfo.InvariantCulture.DateTimeFormat);

--- a/src/PVOutput.Net/Objects/Core/FormatHelper.cs
+++ b/src/PVOutput.Net/Objects/Core/FormatHelper.cs
@@ -27,22 +27,14 @@ namespace PVOutput.Net.Objects.Core
             return ParseDate(dateString);
         }
 
-        internal static DateTime ParseTime(string timeString)
+        internal static TimeSpan ParseTime(string timeString)
         {
-            return DateTime.ParseExact(timeString, "HH:mm", CultureInfo.InvariantCulture.DateTimeFormat);
+            return TimeSpan.ParseExact(timeString, "h\\:mm", CultureInfo.InvariantCulture, TimeSpanStyles.None);
         }
 
         internal static string GetDateAsString(DateTime date)
         {
             return date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
-        }
-
-        internal static string GetCoordinateAsString(PVCoordinate coordinate)
-        {
-            var lat = coordinate.Latitude.ToString("##.####", CultureInfo.CreateSpecificCulture("en-US"));
-            var lon = coordinate.Longitude.ToString("##.####", CultureInfo.CreateSpecificCulture("en-US"));
-
-            return $"{lat},{lon}";
         }
 
         internal static string GetLocationAsString(double? latitude, double? longitude)
@@ -61,6 +53,11 @@ namespace PVOutput.Net.Objects.Core
         internal static string GetTimeAsString(DateTime date)
         {
             return date.ToString("HH:mm", CultureInfo.InvariantCulture.DateTimeFormat);
+        }
+
+        internal static string GetTimeAsString(TimeSpan time)
+        {
+            return time.ToString("h\\:mm", CultureInfo.InvariantCulture.DateTimeFormat);
         }
 
         internal static string GetValueAsString<TInputType>(TInputType? value) where TInputType : struct

--- a/src/PVOutput.Net/Objects/IBaseOutputPost.cs
+++ b/src/PVOutput.Net/Objects/IBaseOutputPost.cs
@@ -31,7 +31,7 @@ namespace PVOutput.Net.Objects
         /// <summary>
         /// Time the peak power was recorded on the output date.
         /// </summary>
-        DateTime? PeakTime { get; set; }
+        TimeSpan? PeakTime { get; set; }
 
         /// <summary>
         /// Solar conditions on the output date.

--- a/src/PVOutput.Net/Objects/IDayStatistics.cs
+++ b/src/PVOutput.Net/Objects/IDayStatistics.cs
@@ -26,7 +26,7 @@ namespace PVOutput.Net.Objects
         /// <summary>
         /// Time the peak power was recorded on the day.
         /// </summary>
-        DateTime PeakTime { get; set; }
+        TimeSpan PeakTime { get; set; }
 
         /// <summary>
         /// Total energy consumed for the day.
@@ -46,7 +46,7 @@ namespace PVOutput.Net.Objects
         /// <summary>
         /// Time the standby power was measured.
         /// </summary>
-        DateTime? StandbyPowerTime { get; set; }
+        TimeSpan? StandbyPowerTime { get; set; }
 
         /// <summary>
         /// Minimum temperature recorded on the day.

--- a/src/PVOutput.Net/Objects/IInsolation.cs
+++ b/src/PVOutput.Net/Objects/IInsolation.cs
@@ -12,7 +12,7 @@ namespace PVOutput.Net.Objects
         /// <summary>
         /// Time of day of the insolation value.
         /// </summary>
-        DateTime Time { get; set; }
+        TimeSpan Time { get; set; }
 
         /// <summary>
         /// Expected power at the time of day.

--- a/src/PVOutput.Net/Objects/IOutput.cs
+++ b/src/PVOutput.Net/Objects/IOutput.cs
@@ -41,7 +41,7 @@ namespace PVOutput.Net.Objects
         /// <summary>
         /// Time the peak power was recorded on the output date.
         /// </summary>
-        DateTime? PeakTime { get; set; }
+        TimeSpan? PeakTime { get; set; }
 
         /// <summary>
         /// Solar conditions on the output date.

--- a/src/PVOutput.Net/Objects/Modules/Implementations/BaseOutputPost.cs
+++ b/src/PVOutput.Net/Objects/Modules/Implementations/BaseOutputPost.cs
@@ -9,7 +9,7 @@ namespace PVOutput.Net.Objects.Modules.Implementations
         public int? EnergyGenerated { get; set; }
         public int? EnergyExported { get; set; }
         public int? PeakPower { get; set; }
-        public DateTime? PeakTime { get; set; }
+        public TimeSpan? PeakTime { get; set; }
         public WeatherCondition Condition { get; set; }
         public decimal? MinimumTemperature { get; set; }
         public decimal? MaximumTemperature { get; set; }

--- a/src/PVOutput.Net/Objects/Modules/Implementations/DayStatistics.cs
+++ b/src/PVOutput.Net/Objects/Modules/Implementations/DayStatistics.cs
@@ -7,11 +7,11 @@ namespace PVOutput.Net.Objects.Modules.Implementations
         public int EnergyGeneration { get; set; }
         public int PowerGeneration { get; set; }
         public int PeakPower { get; set; }
-        public DateTime PeakTime { get; set; }
+        public TimeSpan PeakTime { get; set; }
         public int? EnergyConsumption { get; set; }
         public int? PowerConsumption { get; set; }
         public int? StandbyPower { get; set; }
-        public DateTime? StandbyPowerTime { get; set; }
+        public TimeSpan? StandbyPowerTime { get; set; }
         public decimal? MinimumTemperature { get; set; }
         public decimal? MaximumTemperature { get; set; }
         public decimal? AverageTemperature { get; set; }

--- a/src/PVOutput.Net/Objects/Modules/Implementations/Insolation.cs
+++ b/src/PVOutput.Net/Objects/Modules/Implementations/Insolation.cs
@@ -6,7 +6,7 @@ namespace PVOutput.Net.Objects.Modules.Implementations
 {
     internal class Insolation : IInsolation
     {
-        public DateTime Time { get; set; }
+        public TimeSpan Time { get; set; }
         public int Power { get; set; }
         public int Energy { get; set; }
     }

--- a/src/PVOutput.Net/Objects/Modules/Implementations/Output.cs
+++ b/src/PVOutput.Net/Objects/Modules/Implementations/Output.cs
@@ -11,7 +11,7 @@ namespace PVOutput.Net.Objects.Modules.Implementations
         public int EnergyExported { get; set; }
         public int EnergyUsed { get; set; }
         public int? PeakPower { get; set; }
-        public DateTime? PeakTime { get; set; }
+        public TimeSpan? PeakTime { get; set; }
         public WeatherCondition Condition { get; set; }
         public int? MinimumTemperature { get; set; }
         public int? MaximumTemperature { get; set; }

--- a/src/PVOutput.Net/Objects/Modules/Readers/BatchStatusPostResultStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/BatchStatusPostResultStringReader.cs
@@ -12,7 +12,7 @@ namespace PVOutput.Net.Objects.Modules.Readers
             var properties = new Action<IBatchStatusPostResult, string>[]
             {
                 (t, s) => t.Timestamp = FormatHelper.ParseDate(s),
-                (t, s) => t.Timestamp = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? t.Timestamp : t.Timestamp.Add(FormatHelper.ParseTime(s).TimeOfDay),
+                (t, s) => t.Timestamp = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? t.Timestamp : t.Timestamp.Add(FormatHelper.ParseTime(s)),
                 (t, s) => t.AddedOrUpdated = FormatHelper.GetValueOrDefault<int>(s) == 1
             };
 

--- a/src/PVOutput.Net/Objects/Modules/Readers/FavouriteObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/FavouriteObjectStringReader.cs
@@ -28,8 +28,8 @@ namespace PVOutput.Net.Objects.Modules.Readers
                 (t, s) => t.ArrayTilt = FormatHelper.GetValue<decimal>(s),
                 (t, s) => t.Shade = s,
                 (t, s) => t.InstallDate = FormatHelper.ParseOptionalDate(s),
-                (t, s) => t.Location = new PVCoordinate(FormatHelper.GetValueOrDefault<double>(s), 0), // Latitude
-                (t, s) => t.Location = new PVCoordinate(t.Location.Latitude, FormatHelper.GetValueOrDefault<double>(s)), // Add longitude
+                (t, s) => t.Location = new PVCoordinate(FormatHelper.GetValueOrDefault<decimal>(s), 0), // Latitude
+                (t, s) => t.Location = new PVCoordinate(t.Location.Latitude, FormatHelper.GetValueOrDefault<decimal>(s)), // Add longitude
                 (t, s) => t.StatusInterval = FormatHelper.GetValueOrDefault<int>(s)
             };
 

--- a/src/PVOutput.Net/Objects/Modules/Readers/OutputObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/OutputObjectStringReader.cs
@@ -17,7 +17,7 @@ namespace PVOutput.Net.Objects.Modules.Readers
                 (t, s) => t.EnergyExported = FormatHelper.GetValueOrDefault<int>(s),
                 (t, s) => t.EnergyUsed = FormatHelper.GetValueOrDefault<int>(s),
                 (t, s) => t.PeakPower = FormatHelper.GetValue<int>(s),
-                (t, s) => t.PeakTime = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? (DateTime?)null : t.OutputDate.Add(FormatHelper.ParseTime(s).TimeOfDay),
+                (t, s) => t.PeakTime = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? (TimeSpan?)null : FormatHelper.ParseTime(s),
                 (t, s) => t.Condition = FormatHelper.DescriptionToEnumValue<WeatherCondition>(s),
                 (t, s) => t.MinimumTemperature = FormatHelper.GetValue<int>(s),
                 (t, s) => t.MaximumTemperature = FormatHelper.GetValue<int>(s),

--- a/src/PVOutput.Net/Objects/Modules/Readers/StatusHistoryObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/StatusHistoryObjectStringReader.cs
@@ -12,7 +12,7 @@ namespace PVOutput.Net.Objects.Modules.Readers
             var properties = new Action<IStatusHistory, string>[]
             {
                 (t, s) => t.StatusDate = FormatHelper.ParseDate(s),
-                (t, s) => t.StatusDate = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? t.StatusDate : t.StatusDate.Add(FormatHelper.ParseTime(s).TimeOfDay),
+                (t, s) => t.StatusDate = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? t.StatusDate : t.StatusDate.Add(FormatHelper.ParseTime(s)),
                 (t, s) => t.EnergyGeneration = FormatHelper.GetValue<int>(s),
                 (t, s) => t.EnergyEfficiency = FormatHelper.GetValue<decimal>(s),
                 (t, s) => t.InstantaneousPower = FormatHelper.GetValue<int>(s),

--- a/src/PVOutput.Net/Objects/Modules/Readers/StatusObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/StatusObjectStringReader.cs
@@ -12,7 +12,7 @@ namespace PVOutput.Net.Objects.Modules.Readers
             var properties = new Action<IStatus, string>[]
             {
                 (t, s) => t.Timestamp = FormatHelper.ParseDate(s),
-                (t, s) => t.Timestamp = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? t.Timestamp : t.Timestamp.Add(FormatHelper.ParseTime(s).TimeOfDay),
+                (t, s) => t.Timestamp = s.Equals("NaN", StringComparison.OrdinalIgnoreCase) ? t.Timestamp : t.Timestamp.Add(FormatHelper.ParseTime(s)),
                 (t, s) => t.EnergyGeneration = FormatHelper.GetValue<int>(s),
                 (t, s) => t.PowerGeneration = FormatHelper.GetValue<int>(s),
                 (t, s) => t.EnergyConsumption = FormatHelper.GetValue<int>(s),

--- a/src/PVOutput.Net/Objects/Modules/Readers/SystemObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/SystemObjectStringReader.cs
@@ -38,8 +38,8 @@ namespace PVOutput.Net.Objects.Modules.Readers
                 (t, s) => t.ArrayTilt = FormatHelper.GetValueOrDefault<decimal>(s),
                 (t, s) => t.Shade = s,
                 (t, s) => t.InstallDate = FormatHelper.ParseDate(s),
-                (t, s) => t.Location = new PVCoordinate(FormatHelper.GetValueOrDefault<double>(s), 0), // Latitude
-                (t, s) => t.Location = new PVCoordinate(t.Location.Latitude, FormatHelper.GetValueOrDefault<double>(s)), // Add longitude
+                (t, s) => t.Location = new PVCoordinate(FormatHelper.GetValueOrDefault<decimal>(s), 0), // Latitude
+                (t, s) => t.Location = new PVCoordinate(t.Location.Latitude, FormatHelper.GetValueOrDefault<decimal>(s)), // Add longitude
                 (t, s) => t.StatusInterval = FormatHelper.GetValueOrDefault<int>(s),
                 (t, s) => t.SecondaryNumberOfPanels = FormatHelper.GetValue<int>(s),
                 (t, s) => t.SecondaryPanelPower = FormatHelper.GetValue<int>(s),

--- a/src/PVOutput.Net/Objects/Modules/Readers/SystemSearchResultObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/SystemSearchResultObjectStringReader.cs
@@ -32,8 +32,8 @@ namespace PVOutput.Net.Objects.Modules.Readers
                 (t, s) => t.Panel = s,
                 (t, s) => t.Inverter = s,
                 (t, s) => t.Distance = FormatHelper.GetValue<int>(s),
-                (t, s) => t.Location = new PVCoordinate(FormatHelper.GetValueOrDefault<double>(s), 0), // Latitude
-                (t, s) => t.Location = new PVCoordinate(t.Location.Latitude, FormatHelper.GetValueOrDefault<double>(s)) // Add longitude
+                (t, s) => t.Location = new PVCoordinate(FormatHelper.GetValueOrDefault<decimal>(s), 0), // Latitude
+                (t, s) => t.Location = new PVCoordinate(t.Location.Latitude, FormatHelper.GetValueOrDefault<decimal>(s)) // Add longitude
             };
 
             _parsers.Add((target, reader) => ParsePropertyArray(target, reader, properties));

--- a/src/PVOutput.Net/Objects/PVCoordinate.cs
+++ b/src/PVOutput.Net/Objects/PVCoordinate.cs
@@ -37,7 +37,7 @@ namespace PVOutput.Net.Objects
         /// <returns>Coordinate string.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, "{0},{1}", Latitude, Longitude);
+            return string.Format(CultureInfo.CreateSpecificCulture("en-US"), "{0:N6},{1:N6}", Latitude, Longitude);
         }
 
         /// <summary>

--- a/src/PVOutput.Net/Objects/PVCoordinate.cs
+++ b/src/PVOutput.Net/Objects/PVCoordinate.cs
@@ -13,19 +13,19 @@ namespace PVOutput.Net.Objects
         /// <summary>
         /// Latitudinal part of the coordinate. 
         /// </summary>
-        public double Latitude { get; }
+        public decimal Latitude { get; }
 
         /// <summary>
         /// Longitudinal part of the coordinate.
         /// </summary>
-        public double Longitude { get; }
+        public decimal Longitude { get; }
 
         /// <summary>
         /// Creates a new coordinate.
         /// </summary>
         /// <param name="latitude">Latitude for the location.</param>
         /// <param name="longitude">Longitude for the location.</param>
-        public PVCoordinate(double latitude, double longitude)
+        public PVCoordinate(decimal latitude, decimal longitude)
         {
             Latitude = latitude;
             Longitude = longitude;

--- a/src/PVOutput.Net/Requests/Modules/InsolationRequest.cs
+++ b/src/PVOutput.Net/Requests/Modules/InsolationRequest.cs
@@ -20,7 +20,7 @@ namespace PVOutput.Net.Requests.Modules
         public override IDictionary<string, object> GetUriPathParameters() => new Dictionary<string, object>
         {
             ["d"] = Date != null ? FormatHelper.GetDateAsString(Date.Value) : null,
-            ["ll"] = Coordinate != null ? FormatHelper.GetLocationAsString(Coordinate?.Latitude, Coordinate?.Longitude) : null,
+            ["ll"] = Coordinate?.ToString(),
             ["sid1"] = SystemId
         };
     }

--- a/src/PVOutput.Net/Requests/Modules/SearchRequest.cs
+++ b/src/PVOutput.Net/Requests/Modules/SearchRequest.cs
@@ -21,19 +21,9 @@ namespace PVOutput.Net.Requests.Modules
         public override IDictionary<string, object> GetUriPathParameters() => new Dictionary<string, object>
         {
             ["q"] = SearchQuery,
-            ["ll"] = GetFormatLocation(),
+            ["ll"] = Coordinate?.ToString(),
             ["country_code"] = CountryCode,
             ["country"] = 1
         };
-
-        private string GetFormatLocation()
-        {
-            if (Coordinate == null)
-            {
-                return null;
-            }
-
-            return string.Format(CultureInfo.CreateSpecificCulture("en-US"), "{0:N5},{1:N5}", Coordinate?.Latitude, Coordinate?.Longitude);
-        }
     }
 }

--- a/tests/PVOutput.Net.Tests/Client/PVOutputExceptionTests.cs
+++ b/tests/PVOutput.Net.Tests/Client/PVOutputExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using NUnit.Framework;
+using PVOutput.Net.Responses;
+
+namespace PVOutput.Net.Tests.Client
+{
+    [TestFixture]
+    public class PVOutputExceptionTests
+    {
+        public static IEnumerable DefaultExceptionTests
+        {
+            get
+            {
+                yield return new TestCaseData(new PVOutputException());
+                yield return new TestCaseData(new PVOutputException("Test"));
+                yield return new TestCaseData(new PVOutputException("Test", new InvalidOperationException()));
+            }
+        }
+
+        [Test]
+        [TestCaseSource(typeof(PVOutputExceptionTests), "DefaultExceptionTests")]
+        public void Default_Has_DefaultStatusCode(PVOutputException exception)
+        {
+            Assert.AreEqual((HttpStatusCode)0, exception.StatusCode);
+        }
+
+        public static IEnumerable WithStatusCodeExceptionTests
+        {
+            get
+            {
+                yield return new TestCaseData(new PVOutputException(HttpStatusCode.Unauthorized)).Returns(HttpStatusCode.Unauthorized);
+                yield return new TestCaseData(new PVOutputException(HttpStatusCode.TooManyRequests, "No donation")).Returns(HttpStatusCode.TooManyRequests);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(typeof(PVOutputExceptionTests), "WithStatusCodeExceptionTests")]
+        public HttpStatusCode WithStatusCode_Sets_StatusCode(PVOutputException exception)
+        {
+            return exception.StatusCode;
+        }
+    }
+}

--- a/tests/PVOutput.Net.Tests/Client/PVOutputServiceExtensionsTests.cs
+++ b/tests/PVOutput.Net.Tests/Client/PVOutputServiceExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+using PVOutput.Net.DependencyInjection;
+
+namespace PVOutput.Net.Tests.Client
+{
+    [TestFixture]
+    public class PVOutputServiceExtensionsTests
+    {
+        [Test]
+        public void AddPVOutputClient_Throws_WithNoOptionsAction()
+        {
+            var services = Substitute.For<IServiceCollection>();
+
+            Assert.Throws<ArgumentNullException>(() => {
+                services.AddPVOutputClient(null);
+            });
+        }
+
+        [Test]
+        public void AddPVOutputClient_WithOptionsAction_ExcutesAction()
+        {
+            bool triggered = false;
+            var services = Substitute.For<IServiceCollection>();
+
+            services.AddPVOutputClient(o => { triggered = true; });
+
+            Assert.IsTrue(triggered);
+        }
+    }
+}

--- a/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
@@ -28,8 +28,9 @@ namespace PVOutput.Net.Tests.Handler
                         })
                         .RespondPlainText("");
 
-            _ = await client.System.GetOwnSystemAsync();
+            var response = await client.System.GetOwnSystemAsync();
             testProvider.VerifyNoOutstandingExpectation();
+            Assert.IsTrue(response.ToBoolean());
         }
 
         [Test]
@@ -66,6 +67,7 @@ namespace PVOutput.Net.Tests.Handler
 
             var response = await client.System.GetOwnSystemAsync();
 
+            Assert.IsFalse(response);
             Assert.AreEqual(responseContent, response.Error.Message);
             Assert.AreEqual(statusCode, response.Error.StatusCode);
 

--- a/tests/PVOutput.Net.Tests/Handler/HttpClientProviderTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/HttpClientProviderTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using NUnit.Framework;
+using PVOutput.Net.Requests;
+
+namespace PVOutput.Net.Tests.Handler
+{
+    [TestFixture]
+    public class HttpClientProviderTests
+    {
+        [Test]
+        public void GetHttpClient_Returns_HttpClient()
+        {
+            var provider = new HttpClientProvider();
+            HttpClient client = provider.GetHttpClient();
+
+            Assert.IsNotNull(client);
+        }
+
+        [Test]
+        public void SetupHttpClient_Returns_HttpClient()
+        {
+            var provider = new HttpClientProvider();
+            HttpClient client = provider.SetupHttpClient();
+
+            Assert.IsNotNull(client);
+        }
+
+        [Test]
+        public void GetHttpClient_ReturnsSame_HttpClient()
+        {
+            var provider = new HttpClientProvider();
+            HttpClient client = provider.GetHttpClient();
+
+            HttpClient secondClient = provider.GetHttpClient();
+            Assert.AreSame(client, secondClient);
+        }
+    }
+}

--- a/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
@@ -48,10 +48,10 @@ namespace PVOutput.Net.Tests.Modules.Insolation
             PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
 
             testProvider.ExpectUriFromBase(GETINSOLATION_URL)
-                        .WithQueryString("ll=52.1,40.3")
+                        .WithQueryString("ll=-84.623970,42.728821")
                         .RespondPlainText(INSOLATION_RESPONSE_BASIC);
 
-            var response = await client.Insolation.GetInsolationForLocationAsync(new PVCoordinate(52.1f, 40.3f));
+            var response = await client.Insolation.GetInsolationForLocationAsync(new PVCoordinate(-84.62397f, 42.72882f));
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
         }

--- a/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
@@ -48,7 +48,7 @@ namespace PVOutput.Net.Tests.Modules.Insolation
             PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
 
             testProvider.ExpectUriFromBase(GETINSOLATION_URL)
-                        .WithQueryString("ll=-84.62397,42.72882")
+                        .WithQueryString("ll=-84.623970,42.728820")
                         .RespondPlainText(INSOLATION_RESPONSE_BASIC);
 
             var response = await client.Insolation.GetInsolationForLocationAsync(new PVCoordinate(-84.62397m, 42.72882m));

--- a/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
@@ -16,6 +16,19 @@ namespace PVOutput.Net.Tests.Modules.Insolation
     public partial class InsolationServiceTests : BaseRequestsTest
     {
         [Test]
+        public async Task InsolationService_GetForOwnSystem_CallsCorrectUri()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            testProvider.ExpectUriFromBase(GETINSOLATION_URL)
+                        .RespondPlainText(INSOLATION_RESPONSE_BASIC);
+
+            var response = await client.Insolation.GetInsolationForOwnSystemAsync();
+            testProvider.VerifyNoOutstandingExpectation();
+            AssertStandardResponse(response);
+        }
+
+        [Test]
         public async Task InsolationService_GetForSystem_CallsCorrectUri()
         {
             PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
@@ -25,6 +38,20 @@ namespace PVOutput.Net.Tests.Modules.Insolation
                         .RespondPlainText(INSOLATION_RESPONSE_BASIC);
 
             var response = await client.Insolation.GetInsolationForSystemAsync(54321);
+            testProvider.VerifyNoOutstandingExpectation();
+            AssertStandardResponse(response);
+        }
+
+        [Test]
+        public async Task InsolationService_GetForLocation_CallsCorrectUri()
+        {
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+
+            testProvider.ExpectUriFromBase(GETINSOLATION_URL)
+                        .WithQueryString("ll=52.1,40.3")
+                        .RespondPlainText(INSOLATION_RESPONSE_BASIC);
+
+            var response = await client.Insolation.GetInsolationForLocationAsync(new PVCoordinate(52.1f, 40.3f));
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
         }

--- a/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
@@ -44,11 +44,11 @@ namespace PVOutput.Net.Tests.Modules.Insolation
             {
                 Assert.AreEqual(0, firstInsolation.Energy);
                 Assert.AreEqual(0, firstInsolation.Power);
-                Assert.AreEqual(DateTime.Today.Add(new TimeSpan(6, 0, 0)), firstInsolation.Time);
+                Assert.AreEqual(new TimeSpan(6, 0, 0), firstInsolation.Time);
 
                 Assert.AreEqual(30, lastInsolation.Energy);
                 Assert.AreEqual(123, lastInsolation.Power);
-                Assert.AreEqual(DateTime.Today.Add(new TimeSpan(6, 35, 0)), lastInsolation.Time);
+                Assert.AreEqual(new TimeSpan(6, 35, 0), lastInsolation.Time);
             });
         }
     }

--- a/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Insolation/InsolationServiceTests.cs
@@ -48,10 +48,10 @@ namespace PVOutput.Net.Tests.Modules.Insolation
             PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
 
             testProvider.ExpectUriFromBase(GETINSOLATION_URL)
-                        .WithQueryString("ll=-84.623970,42.728821")
+                        .WithQueryString("ll=-84.62397,42.72882")
                         .RespondPlainText(INSOLATION_RESPONSE_BASIC);
 
-            var response = await client.Insolation.GetInsolationForLocationAsync(new PVCoordinate(-84.62397f, 42.72882f));
+            var response = await client.Insolation.GetInsolationForLocationAsync(new PVCoordinate(-84.62397m, 42.72882m));
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
         }

--- a/tests/PVOutput.Net.Tests/Modules/Output/AddBatchOutputRequestTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/AddBatchOutputRequestTests.cs
@@ -55,7 +55,7 @@ namespace PVOutput.Net.Tests.Modules.Output
         [Test]
         public void Parameter_PeakTime_CreatesCorrectUriParameters()
         {
-            var post = new BatchOutputPost() { PeakTime = new DateTime(2020, 2, 1, 13, 12, 20) };
+            var post = new BatchOutputPost() { PeakTime = new TimeSpan(13, 12, 20) };
             string[] postArray = GetSplitOutputPostLine(post);
             Assert.AreEqual("13:12", postArray[5]);
         }

--- a/tests/PVOutput.Net.Tests/Modules/Output/AddOutputRequestTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/AddOutputRequestTests.cs
@@ -56,7 +56,7 @@ namespace PVOutput.Net.Tests.Modules.Status
         [Test]
         public void Parameter_PeakTime_CreatesCorrectUriParameters()
         {
-            var request = new AddOutputRequest() { Output = new OutputPost() { PeakTime = new DateTime (2020, 3, 1, 10, 30, 12) } };
+            var request = new AddOutputRequest() { Output = new OutputPost() { PeakTime = new TimeSpan(10, 30, 12) } };
 
             var parameters = request.GetUriPathParameters();
             Assert.AreEqual("10:30", parameters["pt"]);

--- a/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
@@ -76,22 +76,9 @@ namespace PVOutput.Net.Tests.Modules.Output
         public void OutputPostBuilder_WithPeakTime_SetsPeakTime()
         {
             var builder = new OutputPostBuilder().SetDate(new DateTime(2020, 1, 1))
-                .SetPeakTime(new DateTime(2020, 1, 1, 10, 10, 0));
+                .SetPeakTime(new TimeSpan(10, 10, 0));
 
-            Assert.AreEqual(new DateTime(2020, 1, 1, 10, 10, 0), builder.OutputPost.PeakTime.Value);
-        }
-
-
-        [Test]
-        public void OutputPostBuilder_WithPeakTimeOnOtherDate_CannotBuild()
-        {
-            var builder = new OutputPostBuilder().SetDate(DateTime.Today)
-                .SetPeakTime(new DateTime(2020, 1, 1, 10, 10, 0));
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                builder.Build();
-            });
+            Assert.AreEqual(new TimeSpan(10, 10, 0), builder.OutputPost.PeakTime.Value);
         }
 
         [Test]

--- a/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/OutputBuilderTests.cs
@@ -76,6 +76,15 @@ namespace PVOutput.Net.Tests.Modules.Output
         public void OutputPostBuilder_WithPeakTime_SetsPeakTime()
         {
             var builder = new OutputPostBuilder().SetDate(new DateTime(2020, 1, 1))
+                .SetPeakTime(12, 22);
+
+            Assert.AreEqual(new TimeSpan(12, 22, 0), builder.OutputPost.PeakTime.Value);
+        }
+
+        [Test]
+        public void OutputPostBuilder_WithPeakTimeSpan_SetsPeakTime()
+        {
+            var builder = new OutputPostBuilder().SetDate(new DateTime(2020, 1, 1))
                 .SetPeakTime(new TimeSpan(10, 10, 0));
 
             Assert.AreEqual(new TimeSpan(10, 10, 0), builder.OutputPost.PeakTime.Value);

--- a/tests/PVOutput.Net.Tests/Modules/Output/OutputServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Output/OutputServiceTests.cs
@@ -257,7 +257,7 @@ namespace PVOutput.Net.Tests.Modules.Output
                     .SetDate(new DateTime(2020, 1, 1)).SetEnergyGenerated(11000).SetEnergyExported(9000).Build(), "d=20200101&g=11000&e=9000");
 
                 yield return new TestCaseData(new OutputPostBuilder()
-                    .SetDate(new DateTime(2020, 1, 1)).SetPeakPower(6500).SetPeakTime(new DateTime(2020, 1, 1, 10, 10, 0)).Build(), "d=20200101&pp=6500&pt=10:10");
+                    .SetDate(new DateTime(2020, 1, 1)).SetPeakPower(6500).SetPeakTime(new TimeSpan(10, 10, 0)).Build(), "d=20200101&pp=6500&pt=10:10");
 
                 yield return new TestCaseData(new OutputPostBuilder()
                     .SetDate(new DateTime(2020, 1, 1)).SetTemperatures(11.2m, 17.8m).Build(), "d=20200101&tm=11.2&tx=17.8");
@@ -347,7 +347,7 @@ namespace PVOutput.Net.Tests.Modules.Output
                 Assert.AreEqual(12719, result.EnergyExported);
                 Assert.AreEqual(8500, result.EnergyUsed);
                 Assert.AreEqual(3422, result.PeakPower);
-                Assert.AreEqual(new DateTime(2018, 9, 1, 12, 0, 0), result.PeakTime);
+                Assert.AreEqual(new TimeSpan(12, 0, 0), result.PeakTime);
                 Assert.AreEqual(WeatherCondition.Fine, result.Condition);
                 Assert.AreEqual(7, result.MinimumTemperature);
                 Assert.AreEqual(23, result.MaximumTemperature);
@@ -390,7 +390,7 @@ namespace PVOutput.Net.Tests.Modules.Output
                 Assert.AreEqual(12719, result.EnergyExported);
                 Assert.AreEqual(8500, result.EnergyUsed);
                 Assert.AreEqual(3422, result.PeakPower);
-                Assert.AreEqual(new DateTime(2018, 9, 1, 12, 0, 0), result.PeakTime);
+                Assert.AreEqual(new TimeSpan(12, 0, 0), result.PeakTime);
                 Assert.AreEqual(WeatherCondition.Fine, result.Condition);
                 Assert.AreEqual(7, result.MinimumTemperature);
                 Assert.AreEqual(23, result.MaximumTemperature);

--- a/tests/PVOutput.Net.Tests/Modules/Search/SearchServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Search/SearchServiceTests.cs
@@ -149,7 +149,7 @@ namespace PVOutput.Net.Tests.Modules.Search
                         .WithQueryString(new Dictionary<string, string>
                             {
                                 { "q", "11km" },
-                                { "ll", "85.32252,31.40098" }
+                                { "ll", "85.322520,31.400980" }
                             })
                         .RespondPlainText("");
 

--- a/tests/PVOutput.Net.Tests/Modules/Search/SearchServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Search/SearchServiceTests.cs
@@ -153,7 +153,7 @@ namespace PVOutput.Net.Tests.Modules.Search
                             })
                         .RespondPlainText("");
 
-            var response = await client.Search.SearchByDistanceAsync(new PVCoordinate(85.32252, 31.40098), 11);
+            var response = await client.Search.SearchByDistanceAsync(new PVCoordinate(85.32252m, 31.40098m), 11);
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
         }

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
@@ -8,6 +8,8 @@ using PVOutput.Net.Objects.Factories;
 using PVOutput.Net.Objects;
 using PVOutput.Net.Tests.Utils;
 using RichardSzalay.MockHttp;
+using PVOutput.Net.Builders;
+using System.Collections;
 
 namespace PVOutput.Net.Tests.Modules.Status
 {
@@ -142,6 +144,21 @@ namespace PVOutput.Net.Tests.Modules.Status
         }
 
         [Test]
+        public async Task StatusService_AddStatus_CallsCorrectUri()
+        {
+            var status = new StatusPostBuilder<IStatusPost>().SetTimeStamp(new DateTime(2020, 1, 1, 12, 22, 0))
+                    .SetGeneration(11000).SetConsumption(9000).Build();
+
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+            testProvider.ExpectUriFromBase(ADDSTATUS_URL)
+                        .WithQueryString("d=20200101&t=12:22&v1=11000&v3=9000&n=0")
+                        .RespondPlainText("");
+
+            await client.Status.AddStatusAsync(status);
+            testProvider.VerifyNoOutstandingExpectation();
+        }
+
+        [Test]
         public void StatusService_AddBatchStatus_WithNullStatuses_Throws()
         {
             PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
@@ -163,6 +180,20 @@ namespace PVOutput.Net.Tests.Modules.Status
             });
         }
 
+        [Test]
+        public async Task StatusService_AddBatchStatus_CallsCorrectUri()
+        {
+            var batchStatus = new StatusPostBuilder<IBatchStatusPost>().SetTimeStamp(new DateTime(2020, 1, 1, 12, 22, 0))
+                    .SetGeneration(11000).SetConsumption(9000).Build();
+
+            PVOutputClient client = TestUtility.GetMockClient(out MockHttpMessageHandler testProvider);
+            testProvider.ExpectUriFromBase(ADDBATCHSTATUS_URL)
+                        .WithQueryString("n=0&data=20200101,12:22,11000,,9000,,,,,,,,,;")
+                        .RespondPlainText("");
+
+            await client.Status.AddBatchStatusAsync(new[] { batchStatus });
+            testProvider.VerifyNoOutstandingExpectation();
+        }
 
         /*
          * Deserialisation tests below

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTests.cs
@@ -55,8 +55,11 @@ namespace PVOutput.Net.Tests.Modules.Status
             testProvider.VerifyNoOutstandingExpectation();
             AssertStandardResponse(response);
 
-            Assert.AreEqual(new DateTime(2020, 1, 31, 14, 40, 0), response.Value.PeakTime);
-            Assert.AreEqual(new DateTime(2020, 1, 31, 15, 5, 0), response.Value.StandbyPowerTime);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(new TimeSpan(14, 40, 0), response.Value.PeakTime);
+                Assert.AreEqual(new TimeSpan(15, 5, 0), response.Value.StandbyPowerTime);
+            });
         }
 
         [Test]
@@ -254,7 +257,7 @@ namespace PVOutput.Net.Tests.Modules.Status
                 Assert.AreEqual(334, result.EnergyGeneration);
                 Assert.AreEqual(1, result.PowerGeneration);
                 Assert.AreEqual(191, result.PeakPower);
-                Assert.AreEqual(DateTime.Today.AddHours(11), result.PeakTime);
+                Assert.AreEqual(new TimeSpan(11, 0, 0), result.PeakTime);
             });
         }
 
@@ -268,12 +271,12 @@ namespace PVOutput.Net.Tests.Modules.Status
                 Assert.AreEqual(334, result.EnergyGeneration);
                 Assert.AreEqual(2, result.PowerGeneration);
                 Assert.AreEqual(82, result.PeakPower);
-                Assert.AreEqual(DateTime.Today.AddHours(14).AddMinutes(40), result.PeakTime);
+                Assert.AreEqual(new TimeSpan(14, 40, 0), result.PeakTime);
 
                 Assert.AreEqual(5811, result.EnergyConsumption);
                 Assert.AreEqual(417, result.PowerConsumption);
                 Assert.AreEqual(255, result.StandbyPower);
-                Assert.AreEqual(DateTime.Today.AddHours(15).AddMinutes(5), result.StandbyPowerTime);
+                Assert.AreEqual(new TimeSpan(15, 5, 0), result.StandbyPowerTime);
             });
         }
 
@@ -287,12 +290,12 @@ namespace PVOutput.Net.Tests.Modules.Status
                 Assert.AreEqual(35302, result.EnergyGeneration);
                 Assert.AreEqual(3, result.PowerGeneration);
                 Assert.AreEqual(5369, result.PeakPower);
-                Assert.AreEqual(DateTime.Today.AddHours(12).AddMinutes(45), result.PeakTime);
+                Assert.AreEqual(new TimeSpan(12, 45, 0), result.PeakTime);
 
                 Assert.AreEqual(31476, result.EnergyConsumption);
                 Assert.AreEqual(606, result.PowerConsumption);
                 Assert.AreEqual(495, result.StandbyPower);
-                Assert.AreEqual(DateTime.Today.AddHours(9).AddMinutes(35), result.StandbyPowerTime);
+                Assert.AreEqual(new TimeSpan(9, 35, 0), result.StandbyPowerTime);
 
                 Assert.AreEqual(18.1d, result.MinimumTemperature);
                 Assert.AreEqual(26.6d, result.MaximumTemperature);

--- a/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTestsData.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/StatusServiceTestsData.cs
@@ -3,6 +3,8 @@
     public partial class StatusServiceTests
     {
         public const string GETSTATUS_URL = "getstatus.jsp";
+        public const string ADDSTATUS_URL = "addstatus.jsp";
+        public const string ADDBATCHSTATUS_URL = "addbatchstatus.jsp";
 
         public const string STATUS_RESPONSE_SINGLE = "20190131,14:00,2930,459,5938,386,0.111,1.8,230.1,1.0,2.0,3.0,4.0,5.0,6.0";
 


### PR DESCRIPTION
All time-specific properties in all objects in the library should be represented as `TimeSpan` instead of `DateTime`.