### PR TITLE
Converted logging events to real EventIds

### DIFF
--- a/src/PVOutput.Net/Objects/Core/LoggingEvents.cs
+++ b/src/PVOutput.Net/Objects/Core/LoggingEvents.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace PVOutput.Net.Objects.Core
 {
@@ -42,64 +43,54 @@ namespace PVOutput.Net.Objects.Core
         /*
          * RequestHandler base events
          */
-        public const int Handler_ExecuteRequest = 10001;
-        public const int Handler_ReceivedResponseContent = 10002;
-        public const int Handler_RequestStatusSuccesful = 10003;
-        public const int Handler_RequestStatusFailed = 10004;
+        public static readonly EventId Handler_ExecuteRequest = new EventId(10001, "ExecuteRequest");
+        public static readonly EventId Handler_ReceivedResponseContent = new EventId(10002, "ReceivedResponseContent");
+        public static readonly EventId Handler_RequestStatusSuccesful = new EventId(10003, "RequestStatusSuccesful");
+        public static readonly EventId Handler_RequestStatusFailed = new EventId(10004, "RequestStatusFailed");
 
         /*
          * Module specific event IDs per request
          */
-        public const int ExtendedService_GetRecentExtendedData = 20101;
-        public const int ExtendedService_GetExtendedDataForPeriod = 20102;
-
-        public const int FavouriteService_GetFavourites = 20201;
-
-        public const int InsolationService_GetInsolationForOwnSystem = 20301;
-        public const int InsolationService_GetInsolationForSystem = 20302;
-        public const int InsolationService_GetInsolationForLocation = 20303;
-
-        public const int MissingService_GetMissingDaysInPeriod = 20401;
-
-        public const int OutputService_GetOutputForDate = 20501;
-        public const int OutputService_GetOutputsForPeriod = 20502;
-        public const int OutputService_GetTeamOutputForDate = 20503;
-        public const int OutputService_GetTeamOutputsForPeriod = 20504;
-        public const int OutputService_GetAggregatedOutputs = 20505;
-        public const int OutputService_AddOutput = 20506;
-        public const int OutputService_AddBatchOutput = 20507;
-
-        public const int SearchService_Search = 20601;
-        public const int SearchService_SearchByName = 20602;
-        public const int SearchService_SearchByPostCodeOrSize = 20603;
-        public const int SearchService_SearchByPostCode = 20604;
-        public const int SearchService_SearchBySize = 20605;
-        public const int SearchService_SearchByPanel = 20606;
-        public const int SearchService_SearchByInverter = 20607;
-        public const int SearchService_SearchByDistance = 20608;
-        public const int SearchService_SearchByTeam = 20609;
-        public const int SearchService_SearchByOrientation = 20610;
-        public const int SearchService_SearchByTilt = 20611;
-        public const int SearchService_GetFavourites = 20612;
-
-        public const int StatisticsService_GetLifetimeStatistics = 20701;
-        public const int StatisticsService_GetStatisticsForPeriod = 20702;
-
-        public const int StatusService_GetStatusForDateTime = 20801;
-        public const int StatusService_GetHistoryForPeriod = 20802;
-        public const int StatusService_GetDayStatisticsForPeriod = 20803;
-        public const int StatusService_AddStatus = 20804;
-        public const int StatusService_AddBatchStatus = 20805;
-        public const int StatusService_DeleteStatus = 20806;
-
-        public const int SupplyService_GetSupply = 20901;
-
-        public const int SystemService_GetOwnSystem = 21001;
-        public const int SystemService_GetOtherSystem = 21002;
-        public const int SystemService_PostSystem = 21003;
-
-        public const int TeamService_GetTeam = 21101;
-        public const int TeamService_JoinTeam = 21102;
-        public const int TeamService_LeaveTeam = 21103;
+        public static readonly EventId ExtendedService_GetRecentExtendedData = new EventId(20101, "GetRecentExtendedData");
+        public static readonly EventId ExtendedService_GetExtendedDataForPeriod = new EventId(20102, "GetExtendedDataForPeriod");
+        public static readonly EventId FavouriteService_GetFavourites = new EventId(20201, "GetFavourites");
+        public static readonly EventId InsolationService_GetInsolationForOwnSystem = new EventId(20301, "GetInsolationForOwnSystem");
+        public static readonly EventId InsolationService_GetInsolationForSystem = new EventId(20302, "GetInsolationForSystem");
+        public static readonly EventId InsolationService_GetInsolationForLocation = new EventId(20303, "GetInsolationForLocation");
+        public static readonly EventId MissingService_GetMissingDaysInPeriod = new EventId(20401, "GetMissingDaysInPeriod");
+        public static readonly EventId OutputService_GetOutputForDate = new EventId(20501, "GetOutputForDate");
+        public static readonly EventId OutputService_GetOutputsForPeriod = new EventId(20502, "GetOutputsForPeriod");
+        public static readonly EventId OutputService_GetTeamOutputForDate = new EventId(20503, "GetTeamOutputForDate");
+        public static readonly EventId OutputService_GetTeamOutputsForPeriod = new EventId(20504, "GetTeamOutputsForPeriod");
+        public static readonly EventId OutputService_GetAggregatedOutputs = new EventId(20505, "GetAggregatedOutputs");
+        public static readonly EventId OutputService_AddOutput = new EventId(20506, "AddOutput");
+        public static readonly EventId OutputService_AddBatchOutput = new EventId(20507, "AddBatchOutput");
+        public static readonly EventId SearchService_Search = new EventId(20601, "Search");
+        public static readonly EventId SearchService_SearchByName = new EventId(20602, "SearchByName");
+        public static readonly EventId SearchService_SearchByPostCodeOrSize = new EventId(20603, "SearchByPostCodeOrSize");
+        public static readonly EventId SearchService_SearchByPostCode = new EventId(20604, "SearchByPostCode");
+        public static readonly EventId SearchService_SearchBySize = new EventId(20605, "SearchBySize");
+        public static readonly EventId SearchService_SearchByPanel = new EventId(20606, "SearchByPanel");
+        public static readonly EventId SearchService_SearchByInverter = new EventId(20607, "SearchByInverter");
+        public static readonly EventId SearchService_SearchByDistance = new EventId(20608, "SearchByDistance");
+        public static readonly EventId SearchService_SearchByTeam = new EventId(20609, "SearchByTeam");
+        public static readonly EventId SearchService_SearchByOrientation = new EventId(20610, "SearchByOrientation");
+        public static readonly EventId SearchService_SearchByTilt = new EventId(20611, "SearchByTilt");
+        public static readonly EventId SearchService_GetFavourites = new EventId(20612, "GetFavourites");
+        public static readonly EventId StatisticsService_GetLifetimeStatistics = new EventId(20701, "GetLifetimeStatistics");
+        public static readonly EventId StatisticsService_GetStatisticsForPeriod = new EventId(20702, "GetStatisticsForPeriod");
+        public static readonly EventId StatusService_GetStatusForDateTime = new EventId(20801, "GetStatusForDateTime");
+        public static readonly EventId StatusService_GetHistoryForPeriod = new EventId(20802, "GetHistoryForPeriod");
+        public static readonly EventId StatusService_GetDayStatisticsForPeriod = new EventId(20803, "GetDayStatisticsForPeriod");
+        public static readonly EventId StatusService_AddStatus = new EventId(20804, "AddStatus");
+        public static readonly EventId StatusService_AddBatchStatus = new EventId(20805, "AddBatchStatus");
+        public static readonly EventId StatusService_DeleteStatus = new EventId(20806, "DeleteStatus");
+        public static readonly EventId SupplyService_GetSupply = new EventId(20901, "GetSupply");
+        public static readonly EventId SystemService_GetOwnSystem = new EventId(21001, "GetOwnSystem");
+        public static readonly EventId SystemService_GetOtherSystem = new EventId(21002, "GetOtherSystem");
+        public static readonly EventId SystemService_PostSystem = new EventId(21003, "PostSystem");
+        public static readonly EventId TeamService_GetTeam = new EventId(21101, "GetTeam");
+        public static readonly EventId TeamService_JoinTeam = new EventId(21102, "JoinTeam");
+        public static readonly EventId TeamService_LeaveTeam = new EventId(21103, "LeaveTeam");
     }
 }

--- a/tests/PVOutput.Net.Tests/Utils/TestOutputLogger.cs
+++ b/tests/PVOutput.Net.Tests/Utils/TestOutputLogger.cs
@@ -36,12 +36,22 @@ namespace PVOutput.Net.Tests.Utils
                     sb.Append('[');
                     sb.Append(kvp.Key);
                     sb.Append(';');
-                    sb.Append(kvp.Value == null ? "<NULL>" : kvp.Value.ToString());
+                    sb.Append(FormatLogValue(kvp.Value));
                     sb.Append("],");
                 }
                 return sb.ToString().TrimEnd(',');
             }
             return state.ToString();
+        }
+
+        private static string FormatLogValue(object value)
+        {
+            if (value is EventId eventId)
+            {
+                return $"({eventId.Id},{eventId.Name})";
+            }
+
+            return value == null ? "<NULL>" : value.ToString();
         }
 
         public void Dispose()


### PR DESCRIPTION
Instead of using `int` constants to manage the possible events, now `EventId` structs are used. Those are understood natively by the `Microsoft.Extensions.Logging` framework.