### PR TITLE
Fixing double UrlEncoding of parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added SearchService.SearchByPostCodeOrSize, a method to search for both parameters at the same time [#31](https://github.com/pyrocumulus/pvoutput.net/pull/31)
 - Added SystemService.PostSystem, enabling the modification of a system's name and/or extended value [#32](https://github.com/pyrocumulus/pvoutput.net/pull/32)
+- Fixed Some services manually UrlEncoded string values resulting in double encoding / value corruption [#33](https://github.com/pyrocumulus/pvoutput.net/issues/33)
 
 ## [0.7.0] - 2020-04-08
 

--- a/src/PVOutput.Net/Modules/SearchService.cs
+++ b/src/PVOutput.Net/Modules/SearchService.cs
@@ -45,7 +45,7 @@ namespace PVOutput.Net.Modules
             Guard.Argument(searchQuery, nameof(searchQuery)).NotEmpty().NotNull();
 
             var handler = new RequestHandler(Client);
-            return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = FormatHelper.UrlEncode(searchQuery), Coordinate = coordinate }, loggingScope, cancellationToken);
+            return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = searchQuery, Coordinate = coordinate }, loggingScope, cancellationToken);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace PVOutput.Net.Modules
             Guard.Argument(postcode, nameof(postcode)).NotEmpty();
 
             var handler = new RequestHandler(Client);
-            var searchQuery = CreateQueryWithKeyword(FormatHelper.UrlEncode(postcode), "postcode");
+            var searchQuery = CreateQueryWithKeyword(postcode, "postcode");
             return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = searchQuery }, loggingScope, cancellationToken);
         }
 
@@ -154,7 +154,7 @@ namespace PVOutput.Net.Modules
             Guard.Argument(panel, nameof(panel)).NotEmpty();
 
             var handler = new RequestHandler(Client);
-            var searchQuery = CreateQueryWithKeyword(FormatHelper.UrlEncode(panel), "panel");
+            var searchQuery = CreateQueryWithKeyword(panel, "panel");
             return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = searchQuery }, loggingScope, cancellationToken);
         }
 
@@ -174,7 +174,7 @@ namespace PVOutput.Net.Modules
             };
 
             Guard.Argument(inverter, nameof(inverter)).NotEmpty();
-            var query = FormatStartsWith(FormatHelper.UrlEncode(inverter), useStartsWith);
+            var query = FormatStartsWith(inverter, useStartsWith);
 
             var handler = new RequestHandler(Client);
             var searchQuery = CreateQueryWithKeyword(query, "inverter");
@@ -250,7 +250,7 @@ namespace PVOutput.Net.Modules
             Guard.Argument(teamName, nameof(teamName)).NotEmpty();
 
             var handler = new RequestHandler(Client);
-            var searchQuery = CreateQueryWithKeyword(FormatHelper.UrlEncode(teamName), "team");
+            var searchQuery = CreateQueryWithKeyword(teamName, "team");
             return handler.ExecuteArrayRequestAsync<ISystemSearchResult>(new SearchRequest { SearchQuery = searchQuery }, loggingScope, cancellationToken);
         }
 

--- a/src/PVOutput.Net/Objects/Core/FormatHelper.cs
+++ b/src/PVOutput.Net/Objects/Core/FormatHelper.cs
@@ -57,17 +57,6 @@ namespace PVOutput.Net.Objects.Core
             return (string)Convert.ChangeType(value, typeof(string), CultureInfo.CreateSpecificCulture("en-US"));
         }
 
-        internal static string UrlEncode(string value)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            // + is only a valid character for encoding space in application/x-www-form-urlencoded content
-            return WebUtility.UrlEncode(value).Replace("+", "%20");
-        }
-
         internal static TResultType? GetValue<TResultType>(string value) where TResultType : struct
         {
             if (string.IsNullOrEmpty(value) || value.Equals("NaN", StringComparison.OrdinalIgnoreCase))

--- a/src/PVOutput.Net/Requests/Handler/RequestHandler.cs
+++ b/src/PVOutput.Net/Requests/Handler/RequestHandler.cs
@@ -272,16 +272,19 @@ namespace PVOutput.Net.Requests.Handler
             return new HttpRequestMessage(request.Method, CreateUrl(request));
         }
 
-        private static string CreateUrl(IRequest request)
+        internal static string CreateUrl(IRequest request)
         {
-            var requestTemplate = new UriTemplate(request.UriTemplate);
+            return CreateUrl(new UriTemplate(request.UriTemplate), request.GetUriPathParameters());
+        }
 
-            foreach (KeyValuePair<string, object> parameter in request.GetUriPathParameters())
+        internal static string CreateUrl(UriTemplate template, IDictionary<string, object> pathParameters)
+        {
+            foreach (KeyValuePair<string, object> parameter in pathParameters)
             {
-                requestTemplate.AddParameter(parameter.Key, parameter.Value);
+                template.AddParameter(parameter.Key, parameter.Value);
             }
 
-            var apiUri = requestTemplate.Resolve();
+            var apiUri = template.Resolve();
             return $"{PVOutputClient.PVOutputBaseUri}{apiUri}";
         }
 

--- a/src/PVOutput.Net/Requests/Modules/AddBatchOutputRequest.cs
+++ b/src/PVOutput.Net/Requests/Modules/AddBatchOutputRequest.cs
@@ -90,7 +90,7 @@ namespace PVOutput.Net.Requests.Modules
 
             if (output.Comments != null)
             {
-                sb.Append(FormatHelper.UrlEncode(output.Comments));
+                sb.Append(output.Comments);
             }
             sb.Append(',');
 

--- a/src/PVOutput.Net/Requests/Modules/AddOutputRequest.cs
+++ b/src/PVOutput.Net/Requests/Modules/AddOutputRequest.cs
@@ -26,7 +26,7 @@ namespace PVOutput.Net.Requests.Modules
             ["cd"] = FormatHelper.GetEnumerationDescription(Output.Condition),
             ["tm"] = FormatHelper.GetValueAsString(Output.MinimumTemperature),
             ["tx"] = FormatHelper.GetValueAsString(Output.MaximumTemperature),
-            ["cm"] = FormatHelper.UrlEncode(Output.Comments),
+            ["cm"] = Output.Comments,
             ["ip"] = FormatHelper.GetValueAsString(Output.PeakEnergyImport),
             ["io"] = FormatHelper.GetValueAsString(Output.OffPeakEnergyImport),
             ["is"] = FormatHelper.GetValueAsString(Output.ShoulderEnergyImport),

--- a/src/PVOutput.Net/Requests/Modules/AddStatusRequest.cs
+++ b/src/PVOutput.Net/Requests/Modules/AddStatusRequest.cs
@@ -33,7 +33,7 @@ namespace PVOutput.Net.Requests.Modules
             ["v10"] = FormatHelper.GetValueAsString(StatusPost.ExtendedValue4),
             ["v11"] = FormatHelper.GetValueAsString(StatusPost.ExtendedValue5),
             ["v12"] = FormatHelper.GetValueAsString(StatusPost.ExtendedValue6),
-            ["m1"] = FormatHelper.UrlEncode(StatusPost.TextMessage)
+            ["m1"] = StatusPost.TextMessage
         };
     }
 }

--- a/tests/PVOutput.Net.Tests/Modules/Status/AddStatusRequestTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/Status/AddStatusRequestTests.cs
@@ -10,6 +10,9 @@ using PVOutput.Net.Tests.Utils;
 using RichardSzalay.MockHttp;
 using PVOutput.Net.Requests.Modules;
 using PVOutput.Net.Objects.Modules.Implementations;
+using PVOutput.Net.Requests.Handler;
+using Tavis.UriTemplates;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 
 namespace PVOutput.Net.Tests.Modules.Status
 {
@@ -98,9 +101,9 @@ namespace PVOutput.Net.Tests.Modules.Status
         [Test]
         public void Parameter_TextMessage_CreatesCorrectUriParameters()
         {
-            var request= CreateRequestWithPost(new StatusPost() { TextMessage = "Text message" });
+            var request = CreateRequestWithPost(new StatusPost() { TextMessage = "Text message" });
             var parameters = request.GetUriPathParameters();
-            Assert.AreEqual("Text%20message", parameters["m1"]);
+            Assert.AreEqual("Text message", parameters["m1"]);
         }
 
         [Test]


### PR DESCRIPTION
Remove all manual `UrlEncode` calls because `Tavis.UriTemplates` actually handles every case better. Manually encoding only results in in double encoding which in turn corrupts values.

Closes #33