### PR TITLE
Improve factory code coverage

### DIFF
--- a/src/PVOutput.Net/Objects/Core/IArrayStringFactory.cs
+++ b/src/PVOutput.Net/Objects/Core/IArrayStringFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace PVOutput.Net.Objects.Core
+{
+    internal interface IArrayStringFactory<TObjectType> : IObjectStringFactory<TObjectType>
+    {
+        IArrayStringReader<TObjectType> CreateArrayReader();
+    }
+}

--- a/src/PVOutput.Net/Objects/Core/IObjectStringFactory.cs
+++ b/src/PVOutput.Net/Objects/Core/IObjectStringFactory.cs
@@ -2,10 +2,8 @@
 
 namespace PVOutput.Net.Objects.Core
 {
-    internal interface IStringFactory<TObjectType>
+    internal interface IObjectStringFactory<TObjectType>
     {
         IObjectStringReader<TObjectType> CreateObjectReader();
-
-        IArrayStringReader<TObjectType> CreateArrayReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/AggregatedOutputFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/AggregatedOutputFactory.cs
@@ -1,10 +1,10 @@
-using PVOutput.Net.Objects.Core;
+﻿using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class AggregatedOutputFactory : IStringFactory<IAggregatedOutput>
+    internal class AggregatedOutputFactory : IArrayStringFactory<IAggregatedOutput>
     {
         public IArrayStringReader<IAggregatedOutput> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IAggregatedOutput>();
 

--- a/src/PVOutput.Net/Objects/Factories/BatchStatusPostResultFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/BatchStatusPostResultFactory.cs
@@ -4,7 +4,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class BatchStatusPostResultFactory : IStringFactory<IBatchStatusPostResult>
+    internal class BatchStatusPostResultFactory : IArrayStringFactory<IBatchStatusPostResult>
     {
         public IArrayStringReader<IBatchStatusPostResult> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IBatchStatusPostResult>();
 

--- a/src/PVOutput.Net/Objects/Factories/DayStatisticsFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/DayStatisticsFactory.cs
@@ -1,12 +1,11 @@
-﻿using PVOutput.Net.Objects.Core;
+﻿using System;
+using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class DayStatisticsFactory : IStringFactory<IDayStatistics>
+    internal class DayStatisticsFactory : IObjectStringFactory<IDayStatistics>
     {
-        public IArrayStringReader<IDayStatistics> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IDayStatistics>();
-
         public IObjectStringReader<IDayStatistics> CreateObjectReader() => new DayStatisticsObjectStringReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/ExtendedFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/ExtendedFactory.cs
@@ -5,7 +5,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class ExtendedFactory : IStringFactory<IExtended>
+    internal class ExtendedFactory : IArrayStringFactory<IExtended>
     {
         public IArrayStringReader<IExtended> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IExtended>();
 

--- a/src/PVOutput.Net/Objects/Factories/FavouriteFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/FavouriteFactory.cs
@@ -5,7 +5,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class FavouriteFactory : IStringFactory<IFavourite>
+    internal class FavouriteFactory : IArrayStringFactory<IFavourite>
     {
         public IArrayStringReader<IFavourite> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IFavourite>('\n');
 

--- a/src/PVOutput.Net/Objects/Factories/InsolationFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/InsolationFactory.cs
@@ -5,7 +5,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class InsolationFactory : IStringFactory<IInsolation>
+    internal class InsolationFactory : IArrayStringFactory<IInsolation>
     {
         public IArrayStringReader<IInsolation> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IInsolation>();
 

--- a/src/PVOutput.Net/Objects/Factories/MissingFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/MissingFactory.cs
@@ -1,14 +1,12 @@
-using System;
+﻿using System;
 using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class MissingFactory : IStringFactory<IMissing>
+    internal class MissingFactory : IObjectStringFactory<IMissing>
     {
-        public IArrayStringReader<IMissing> CreateArrayReader() => throw new NotImplementedException();
-
         public IObjectStringReader<IMissing> CreateObjectReader() => new MissingObjectStringReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/OutputFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/OutputFactory.cs
@@ -1,10 +1,10 @@
-using PVOutput.Net.Objects.Core;
+﻿using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class OutputFactory : IStringFactory<IOutput>
+    internal class OutputFactory : IArrayStringFactory<IOutput>
     {
         public IArrayStringReader<IOutput> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IOutput>();
 

--- a/src/PVOutput.Net/Objects/Factories/StatisticFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/StatisticFactory.cs
@@ -1,13 +1,11 @@
-using PVOutput.Net.Objects.Core;
+﻿using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class StatisticFactory : IStringFactory<IStatistic>
+    internal class StatisticFactory : IObjectStringFactory<IStatistic>
     {
-        public IArrayStringReader<IStatistic> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IStatistic>();
-
         public IObjectStringReader<IStatistic> CreateObjectReader() => new StatisticObjectStringReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/StatusFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/StatusFactory.cs
@@ -4,10 +4,8 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class StatusFactory : IStringFactory<IStatus>
+    internal class StatusFactory : IObjectStringFactory<IStatus>
     {
-        public IArrayStringReader<IStatus> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IStatus>();
-
         public IObjectStringReader<IStatus> CreateObjectReader() => new StatusObjectStringReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/StatusHistoryFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/StatusHistoryFactory.cs
@@ -4,7 +4,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class StatusHistoryFactory : IStringFactory<IStatusHistory>
+    internal class StatusHistoryFactory : IArrayStringFactory<IStatusHistory>
     {
         public IArrayStringReader<IStatusHistory> CreateArrayReader() => new CharacterDelimitedArrayStringReader<IStatusHistory>();
 

--- a/src/PVOutput.Net/Objects/Factories/StringFactoryContainer.cs
+++ b/src/PVOutput.Net/Objects/Factories/StringFactoryContainer.cs
@@ -29,28 +29,32 @@ namespace PVOutput.Net.Objects.Factories
             _readerFactories.Add(typeof(ISystemSearchResult), new SystemSearchResultFactory());
         }
 
-        public static IStringFactory<TReturnType> GetStringFactory<TReturnType>()
+        private static object GetObjectStringFactory<TReturnType>()
         {
-            var type = typeof(TReturnType);
-
+            Type type = typeof(TReturnType);
             if (!_readerFactories.ContainsKey(type))
             {
-                throw new NotSupportedException($"Factory for {type} is not known");
+                throw new InvalidOperationException($"Factory for {type} is not known");
             }
 
-            return (IStringFactory<TReturnType>)_readerFactories[type];
+            return _readerFactories[type];
         }
 
         public static IObjectStringReader<TReturnType> CreateObjectReader<TReturnType>()
         {
-            var factory = GetStringFactory<TReturnType>();
+            // Currently every factory is an ObjectStringFactory at minimum
+            var factory = GetObjectStringFactory<TReturnType>() as IObjectStringFactory<TReturnType>;
             return factory.CreateObjectReader();
         }
 
         public static IArrayStringReader<TReturnType> CreateArrayReader<TReturnType>()
         {
-            var factory = GetStringFactory<TReturnType>();
-            return factory.CreateArrayReader();
+            var factory = GetObjectStringFactory<TReturnType>();
+            if (factory is IArrayStringFactory<TReturnType> arrayFactory)
+            {
+                return arrayFactory.CreateArrayReader();
+            }
+            throw new InvalidOperationException($"Factory for {typeof(TReturnType)} is not an array factory");
         }
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/SupplyFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/SupplyFactory.cs
@@ -4,7 +4,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class SupplyFactory : IStringFactory<ISupply>
+    internal class SupplyFactory : IArrayStringFactory<ISupply>
     {
         public IArrayStringReader<ISupply> CreateArrayReader() => new CharacterDelimitedArrayStringReader<ISupply>();
 

--- a/src/PVOutput.Net/Objects/Factories/SystemFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/SystemFactory.cs
@@ -1,13 +1,11 @@
-using PVOutput.Net.Objects.Core;
+﻿using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class SystemFactory : IStringFactory<ISystem>
+    internal class SystemFactory : IObjectStringFactory<ISystem>
     {
-        public IArrayStringReader<ISystem> CreateArrayReader() => new CharacterDelimitedArrayStringReader<ISystem>();
-
         public IObjectStringReader<ISystem> CreateObjectReader() => new SystemObjectStringReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/SystemSearchResultFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/SystemSearchResultFactory.cs
@@ -5,7 +5,7 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class SystemSearchResultFactory : IStringFactory<ISystemSearchResult>
+    internal class SystemSearchResultFactory : IArrayStringFactory<ISystemSearchResult>
     {
         public IArrayStringReader<ISystemSearchResult> CreateArrayReader() => new LineDelimitedArrayStringReader<ISystemSearchResult>();
 

--- a/src/PVOutput.Net/Objects/Factories/TeamFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/TeamFactory.cs
@@ -5,10 +5,8 @@ using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class TeamFactory : IStringFactory<ITeam>
+    internal class TeamFactory : IObjectStringFactory<ITeam>
     {
-        public IArrayStringReader<ITeam> CreateArrayReader() => throw new NotImplementedException();
-
         public IObjectStringReader<ITeam> CreateObjectReader() => new TeamObjectStringReader();
     }
 }

--- a/src/PVOutput.Net/Objects/Factories/TeamOutputFactory.cs
+++ b/src/PVOutput.Net/Objects/Factories/TeamOutputFactory.cs
@@ -1,10 +1,10 @@
-using PVOutput.Net.Objects.Core;
+﻿using PVOutput.Net.Objects.Core;
 using PVOutput.Net.Objects.Modules;
 using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Objects.Factories
 {
-    internal class TeamOutputFactory : IStringFactory<ITeamOutput>
+    internal class TeamOutputFactory : IArrayStringFactory<ITeamOutput>
     {
         public IArrayStringReader<ITeamOutput> CreateArrayReader() => new CharacterDelimitedArrayStringReader<ITeamOutput>();
 

--- a/src/PVOutput.Net/Requests/Handler/RequestHandler.cs
+++ b/src/PVOutput.Net/Requests/Handler/RequestHandler.cs
@@ -60,7 +60,7 @@ namespace PVOutput.Net.Requests.Handler
             }
             finally
             {
-                responseMessage?.Dispose();
+                responseMessage.Dispose();
             }
         }
 
@@ -96,7 +96,7 @@ namespace PVOutput.Net.Requests.Handler
             }
             finally
             {
-                responseMessage?.Dispose();
+                responseMessage.Dispose();
             }
         }
 
@@ -129,7 +129,7 @@ namespace PVOutput.Net.Requests.Handler
             }
             finally
             {
-                responseMessage?.Dispose();
+                responseMessage.Dispose();
             }
         }
 

--- a/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using PVOutput.Net.Enums;
 using PVOutput.Net.Objects;
+using PVOutput.Net.Objects.Core;
+using PVOutput.Net.Objects.Factories;
 using PVOutput.Net.Objects.Modules.Implementations;
 using PVOutput.Net.Responses;
 using PVOutput.Net.Tests.Utils;
@@ -224,6 +226,42 @@ namespace PVOutput.Net.Tests.Handler
                 Assert.That((bool)response2, Is.False);
                 Assert.That((bool)response3, Is.False);
             });
+        }
+
+        [Test]
+        public async Task BaseObjectReader_WithNullStream_ReturnsDefaultForType()
+        {
+            IObjectStringReader<IStatus> reader = StringFactoryContainer.CreateObjectReader<IStatus>();
+            IStatus content = await reader.ReadObjectAsync(stream: null, cancellationToken: default).ConfigureAwait(false);
+
+            Assert.That(content, Is.Null);
+        }
+
+        [Test]
+        public async Task BaseArrayReader_WithNullStream_ReturnsDefaultForType()
+        {
+            IArrayStringReader<ISystemSearchResult> reader = StringFactoryContainer.CreateArrayReader<ISystemSearchResult>();
+            IEnumerable<ISystemSearchResult> content = await reader.ReadArrayAsync(stream: null, cancellationToken: default).ConfigureAwait(false);
+
+            Assert.That(content, Is.Null);
+        }
+
+        [Test]
+        public async Task CharacterDelimitedArrayReader_WithNullStream_ReturnsDefaultForType()
+        {
+            IArrayStringReader<ISystemSearchResult> reader = new CharacterDelimitedArrayStringReader<ISystemSearchResult>();
+            IEnumerable<ISystemSearchResult> content = await reader.ReadArrayAsync(stream: null, cancellationToken: default).ConfigureAwait(false);
+
+            Assert.That(content, Is.Null);
+        }
+
+        [Test]
+        public async Task LineDelimitedArrayReader_WithNullStream_ReturnsDefaultForType()
+        {
+            IArrayStringReader<ISystemSearchResult> reader = new LineDelimitedArrayStringReader<ISystemSearchResult>();
+            IEnumerable<ISystemSearchResult> content = await reader.ReadArrayAsync(stream: null, cancellationToken: default).ConfigureAwait(false);
+
+            Assert.That(content, Is.Null);
         }
     }
 }

--- a/tests/PVOutput.Net.Tests/Handler/OtherObjectTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/OtherObjectTests.cs
@@ -26,7 +26,14 @@ namespace PVOutput.Net.Tests.Handler
 
         [Test]
         [TestCaseSource(typeof(OtherObjectTests), nameof(PVCoordinateRegularEqualityTestCases))]
-        public bool PVCoordinate_Equals_ReturnsValueEquality(PVCoordinate coordinate1, PVCoordinate coordinate2)
+        public bool PVCoordinate_EqualsByType_ReturnsValueEquality(PVCoordinate coordinate1, PVCoordinate coordinate2)
+        {
+            return coordinate1.Equals(coordinate2);
+        }
+
+        [Test]
+        [TestCaseSource(typeof(OtherObjectTests), nameof(PVCoordinateRegularEqualityTestCases))]
+        public bool PVCoordinate_EqualsByObject_ReturnsValueEquality(PVCoordinate coordinate1, object coordinate2)
         {
             return coordinate1.Equals(coordinate2);
         }
@@ -74,7 +81,14 @@ namespace PVOutput.Net.Tests.Handler
 
         [Test]
         [TestCaseSource(typeof(OtherObjectTests), nameof(ExtendedDataConfigurationRegularEqualityTestCases))]
-        public bool ExtendedDataConfiguration_Equals_ReturnsValueEquality(ExtendedDataConfiguration configuration1, ExtendedDataConfiguration configuration2)
+        public bool ExtendedDataConfiguration_EqualsByType_ReturnsValueEquality(ExtendedDataConfiguration configuration1, ExtendedDataConfiguration configuration2)
+        {
+            return configuration1.Equals(configuration2);
+        }        
+        
+        [Test]
+        [TestCaseSource(typeof(OtherObjectTests), nameof(ExtendedDataConfigurationRegularEqualityTestCases))]
+        public bool ExtendedDataConfiguration_EqualsByObject_ReturnsValueEquality(ExtendedDataConfiguration configuration1, object configuration2)
         {
             return configuration1.Equals(configuration2);
         }

--- a/tests/PVOutput.Net.Tests/Handler/OtherObjectTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/OtherObjectTests.cs
@@ -5,6 +5,9 @@ using System.Text;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using NUnit.Framework;
 using PVOutput.Net.Objects;
+using PVOutput.Net.Objects.Core;
+using PVOutput.Net.Objects.Factories;
+using PVOutput.Net.Objects.Modules.Readers;
 
 namespace PVOutput.Net.Tests.Handler
 {
@@ -89,6 +92,7 @@ namespace PVOutput.Net.Tests.Handler
         {
             return configuration1 == configuration2;
         }
+
         public static IEnumerable ExtendedDataConfigurationInvertedEqualityTestCases
         {
             get
@@ -104,6 +108,36 @@ namespace PVOutput.Net.Tests.Handler
         public bool ExtendedDataConfiguration_OperatorNotEquals_ReturnsValueEquality(ExtendedDataConfiguration configuration1, ExtendedDataConfiguration configuration2)
         {
             return configuration1 != configuration2;
+        }
+
+        [Test]
+        public void StringFactoryContainer_ForType_CreatesObjectReader()
+        {
+            IObjectStringReader<IStatus> reader = StringFactoryContainer.CreateObjectReader<IStatus>();
+            Assert.That(reader, Is.TypeOf<StatusObjectStringReader>());
+        }
+
+        [Test]
+        public void StringFactoryContainer_ForType_CreatesArrayReader()
+        {
+            IArrayStringReader<ISystemSearchResult> reader = StringFactoryContainer.CreateArrayReader<ISystemSearchResult>();
+            Assert.That(reader, Is.TypeOf<LineDelimitedArrayStringReader<ISystemSearchResult>>());
+        }
+
+        [Test]
+        public void StringFactoryContainer_ForUnknownType_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => {
+                _ = StringFactoryContainer.CreateObjectReader<IServiceProvider>();
+            });
+        }
+
+        [Test]
+        public void StringFactoryContainer_ForTypeWithoutArrayReader_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => {
+                _ = StringFactoryContainer.CreateArrayReader<IStatus>();
+            });
         }
     }
 }


### PR DESCRIPTION
Cleaned up the factories for the creation of object and array readers. A couple of factories had `NotImplementedException` / `NotSupportedException` for the creation of array readers because the serialisation either didn't support it or because no request returned that type in an array form. This removes those 'half' interface implementations by splitting the interface.