### PR TITLE
If own system has no secondary panel, GetOwnSystem() throws

### DIFF
--- a/src/PVOutput.Net/Objects/Core/FormatHelper.cs
+++ b/src/PVOutput.Net/Objects/Core/FormatHelper.cs
@@ -113,5 +113,30 @@ namespace PVOutput.Net.Objects.Core
 
             throw new ArgumentException($"Invalid description '{enumerationDescription}' for enum " + type.Name, nameof(enumerationDescription));
         }
+
+        /// <summary>
+        /// Returns enum value corresponding to given textual string value. If no value could be found, it returns null.
+        /// </summary>
+        /// <typeparam name="TEnumType">Enum to cast the string to.</typeparam>
+        /// <param name="enumerationDescription">String containing the enum description.</param>
+        /// <returns>An enum value if the description is found, null if no corresponding enum could be found.</returns>
+        /// <exception cref="ArgumentException">Throws if supplied type is not an Enum-type.</exception>
+        public static TEnumType? DescriptionToNullableEnumValue<TEnumType>(this string enumerationDescription) where TEnumType : struct
+        {
+            Type type = typeof(TEnumType);
+
+            if (!type.IsEnum)
+            {
+                throw new ArgumentException("Type parameter must be of Enum type");
+            }
+
+            foreach (TEnumType val in Enum.GetValues(type))
+            {
+                if (val.GetEnumerationDescription() == enumerationDescription)
+                    return val;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/PVOutput.Net/Objects/Modules/Readers/SystemObjectStringReader.cs
+++ b/src/PVOutput.Net/Objects/Modules/Readers/SystemObjectStringReader.cs
@@ -43,7 +43,7 @@ namespace PVOutput.Net.Objects.Modules.Readers
                 (t, s) => t.StatusInterval = FormatHelper.GetValueOrDefault<int>(s),
                 (t, s) => t.SecondaryNumberOfPanels = FormatHelper.GetValue<int>(s),
                 (t, s) => t.SecondaryPanelPower = FormatHelper.GetValue<int>(s),
-                (t, s) => t.SecondaryOrientation = !string.IsNullOrWhiteSpace(s) ? FormatHelper.DescriptionToEnumValue<Orientation>(s) : (Orientation?)null,
+                (t, s) => t.SecondaryOrientation = !string.IsNullOrWhiteSpace(s) ? FormatHelper.DescriptionToNullableEnumValue<Orientation>(s) : (Orientation?)null,
                 (t, s) => t.SecondaryArrayTilt = FormatHelper.GetValue<decimal>(s)
             };
 

--- a/tests/PVOutput.Net.Tests/Modules/System/SystemServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/System/SystemServiceTests.cs
@@ -97,6 +97,40 @@ namespace PVOutput.Net.Tests.Modules.System
         }
 
         [Test]
+        public async Task SystemReader_OwnSystemWithoutSecondaryPanelResponse_CreatesCorrectObject()
+        {
+            ISystem result = await TestUtility.ExecuteObjectReaderByTypeAsync<ISystem>(OWNSYSTEM_RESPONSE_WITHOUT_SECONDARYPANEL);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.SystemName, Is.EqualTo("Test System"));
+                Assert.That(result.SystemSize, Is.EqualTo(4125));
+                Assert.That(result.Postcode, Is.EqualTo(1234));
+                Assert.That(result.NumberOfPanels, Is.EqualTo(15));
+                Assert.That(result.PanelPower, Is.EqualTo(275));
+                Assert.That(result.PanelBrand, Is.EqualTo("JA Solar mono"));
+                Assert.That(result.NumberOfInverters, Is.EqualTo(1));
+                Assert.That(result.InverterPower, Is.EqualTo(5500));
+                Assert.That(result.InverterBrand, Is.EqualTo("Fronius Primo 3.6-1"));
+                Assert.That(result.Orientation, Is.EqualTo(Orientation.East));
+                Assert.That(result.ArrayTilt, Is.EqualTo(53.0m));
+                Assert.That(result.Shade, Is.EqualTo(Shade.None));
+                Assert.That(result.InstallDate, Is.Null);
+                Assert.That(result.SecondaryOrientation, Is.Null);
+                Assert.That(result.SecondaryArrayTilt, Is.Null);
+                Assert.That(result.SecondaryNumberOfPanels, Is.Null);
+                Assert.That(result.SecondaryPanelPower, Is.Null);
+                Assert.That(result.Location.Latitude, Is.EqualTo(51.0d));
+                Assert.That(result.Location.Longitude, Is.EqualTo(6.1d));
+                Assert.That(result.StatusInterval, Is.EqualTo(5));
+                Assert.That(result.Teams, Has.Count.Zero);
+                Assert.That(result.Donations, Is.EqualTo(0));
+                Assert.That(result.ExtendedDataConfig, Has.Count.Zero);
+                Assert.That(result.MonthlyGenerationEstimates, Has.Count.Zero);
+                Assert.That(result.MonthlyConsumptionEstimates, Has.Count.Zero);
+            });
+        }
+
+        [Test]
         public async Task SystemReader_ForResponse_CreatesCorrectObject()
         {
             ISystem result = await TestUtility.ExecuteObjectReaderByTypeAsync<ISystem>(SYSTEM_RESPONSE_EXTENDED);

--- a/tests/PVOutput.Net.Tests/Modules/System/SystemSystemTestsData.cs
+++ b/tests/PVOutput.Net.Tests/Modules/System/SystemSystemTestsData.cs
@@ -7,6 +7,8 @@
         public const string POSTSYSTEM_URL = "postsystem.jsp";
 
         public const string SYSTEM_RESPONSE_SIMPLE = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,E,,No,,51.0,6.1,5;;";
+        
+        public const string OWNSYSTEM_RESPONSE_WITHOUT_SECONDARYPANEL = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,E,53.0,No,,51.0,6.1,5,,,null,NaN;";
 
         public const string SYSTEM_RESPONSE_EXTENDED = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,E,53.1,No,20160822,51.0,6.1,5,10,190,W,33.5;17.37,20.46,20.2,25.4,22.65,40.0;12,232,480,512;1;DC-1 Voltage,V,DC-2 Voltage,V,DC-DC Booster Temp,°C,DC-1 Power (2x13x290Wp),W;61,106,252,380,430,425,417,354,253,159,70,48,400,350,300,250,200,150,100,175,275,375,475,525";
 


### PR DESCRIPTION
Fixes #111 

Unfortunately more api responses could suffer the same issue, but I haven't seen others yet.