### PR TITLE
fix: don't throw on cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - **BREAKING**: Removed add batch output from API. Please use the `AddOutputsAsync` method from now on. This is donation only. [#78](https://github.com/pyrocumulus/pvoutput.net/pull/78)
-- **BREAKING**: Some implementations which have been properly interfaced, are reduced to internal visibility from now on. LINK HERE [#117](https://github.com/pyrocumulus/pvoutput.net/pull/117)
+- **BREAKING**: Some implementations which have been properly interfaced, are reduced to internal visibility from now on. [#117](https://github.com/pyrocumulus/pvoutput.net/pull/117)
 
 ### Updated
 
 - Updated `Microsoft.Extensions.DependencyInjection.Abstractions` from `v6.0.0` to `v6.0.1` [#114](https://github.com/pyrocumulus/pvoutput.net/pull/114)
+
+### Fixed
+
+- Fixed Do not throw exception on cancellation of request [#124](https://github.com/pyrocumulus/pvoutput.net/pull/124) - Contribution [CodeCasterNL](https://github.com/CodeCasterNL)
 
 ## [0.10.0] - 2022-03-16
 

--- a/src/PVOutput.Net/Requests/Handler/RequestHandler.cs
+++ b/src/PVOutput.Net/Requests/Handler/RequestHandler.cs
@@ -79,7 +79,7 @@ namespace PVOutput.Net.Requests.Handler
             }
             finally
             {
-                responseMessage.Dispose();
+                responseMessage?.Dispose();
             }
         }
 
@@ -115,7 +115,7 @@ namespace PVOutput.Net.Requests.Handler
             }
             finally
             {
-                responseMessage.Dispose();
+                responseMessage?.Dispose();
             }
         }
 
@@ -148,7 +148,7 @@ namespace PVOutput.Net.Requests.Handler
             }
             finally
             {
-                responseMessage.Dispose();
+                responseMessage?.Dispose();
             }
         }
 

--- a/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
@@ -168,7 +168,7 @@ namespace PVOutput.Net.Tests.Handler
             testProvider.ExpectUriFromBase("postsystem.jsp")
                 .Respond(async _ =>
                 {
-                    // This should let the client hang on ExecuteSingleItemRequest until it's canceled.
+                    // This should let the client hang on ExecutePostRequest until it's canceled.
                     await Task.Delay(1000);
 
                     throw new InvalidOperationException("Should have been canceled");


### PR DESCRIPTION
When the cancellationtoken is cancelled during the execution of a request, an `OperationCanceledException` is thrown. The `finally` blocks then tried to dispose a null `responseMessage`, throwing a `NullReferenceException` instead.