### PR TITLE
Try to fix exception type swapping

### DIFF
--- a/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
@@ -102,7 +102,7 @@ namespace PVOutput.Net.Tests.Handler
 
             Task task = null;
 
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () =>
             {
                 task = Task.Run(() => client.System.GetOwnSystemAsync(cancellationTokenSource.Token));
 
@@ -139,7 +139,7 @@ namespace PVOutput.Net.Tests.Handler
 
             Task task = null;
 
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () =>
             {
                 task = Task.Run(() => client.Search.SearchAsync("test", cancellationToken: cancellationTokenSource.Token));
 
@@ -175,8 +175,8 @@ namespace PVOutput.Net.Tests.Handler
                 });
 
             Task task = null;
-
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () =>
             {
                 task = Task.Run(() => client.System.PostSystem(systemId: 42, cancellationToken: cancellationTokenSource.Token));
 

--- a/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
+++ b/tests/PVOutput.Net.Tests/Handler/BaseRequestHandlingTests.cs
@@ -102,6 +102,9 @@ namespace PVOutput.Net.Tests.Handler
 
             Task task = null;
 
+            // Test through Is.InstanceOf<> instead of ThrowsAsync<TActual>
+            // In Linux containers the exception type can sometimes switch to TaskCanceledException based on timing
+            // This way we allow OperationCanceledException as well as TaskCanceledException
             Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () =>
             {
                 task = Task.Run(() => client.System.GetOwnSystemAsync(cancellationTokenSource.Token));
@@ -139,6 +142,9 @@ namespace PVOutput.Net.Tests.Handler
 
             Task task = null;
 
+            // Test through Is.InstanceOf<> instead of ThrowsAsync<TActual>
+            // In Linux containers the exception type can sometimes switch to TaskCanceledException based on timing
+            // This way we allow OperationCanceledException as well as TaskCanceledException
             Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () =>
             {
                 task = Task.Run(() => client.Search.SearchAsync("test", cancellationToken: cancellationTokenSource.Token));
@@ -175,7 +181,10 @@ namespace PVOutput.Net.Tests.Handler
                 });
 
             Task task = null;
-            
+
+            // Test through Is.InstanceOf<> instead of ThrowsAsync<TActual>
+            // In Linux containers the exception type can sometimes switch to TaskCanceledException based on timing
+            // This way we allow OperationCanceledException as well as TaskCanceledException
             Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () =>
             {
                 task = Task.Run(() => client.System.PostSystem(systemId: 42, cancellationToken: cancellationTokenSource.Token));


### PR DESCRIPTION
The three new unit tests sometimes fail in the workflow's Linux containers with:

```
  Error Message:
     Expected: <System.OperationCanceledException>
  But was:  <System.Threading.Tasks.TaskCanceledException: A task was canceled.
```

See also
https://github.com/dotnet/runtime/issues/28125#issuecomment-508649867