### PR TITLE
Add support for EastWest panel orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- Added support for undocumented panel orientation 'EastWest' [#131](https://github.com/pyrocumulus/pvoutput.net/pull/131) - Contribution [CodeCasterNL](https://github.com/CodeCasterNL)
+
 ## [0.11.0] - 2022-05-05
 
 ### Changed

--- a/src/PVOutput.Net/Enums/Orientation.cs
+++ b/src/PVOutput.Net/Enums/Orientation.cs
@@ -56,6 +56,12 @@ namespace PVOutput.Net.Enums
         /// NorthWest
         /// </summary>
         [Description("NW")]
-        NorthWest = 7
+        NorthWest = 7,
+
+        /// <summary>
+        /// EastWest
+        /// </summary>
+        [Description("EW")]
+        EastWest = 8
     }
 }

--- a/tests/PVOutput.Net.Tests/Modules/System/SystemServiceTests.cs
+++ b/tests/PVOutput.Net.Tests/Modules/System/SystemServiceTests.cs
@@ -111,7 +111,7 @@ namespace PVOutput.Net.Tests.Modules.System
                 Assert.That(result.NumberOfInverters, Is.EqualTo(1));
                 Assert.That(result.InverterPower, Is.EqualTo(5500));
                 Assert.That(result.InverterBrand, Is.EqualTo("Fronius Primo 3.6-1"));
-                Assert.That(result.Orientation, Is.EqualTo(Orientation.East));
+                Assert.That(result.Orientation, Is.EqualTo(Orientation.EastWest));
                 Assert.That(result.ArrayTilt, Is.EqualTo(53.0m));
                 Assert.That(result.Shade, Is.EqualTo(Shade.None));
                 Assert.That(result.InstallDate, Is.Null);

--- a/tests/PVOutput.Net.Tests/Modules/System/SystemSystemTestsData.cs
+++ b/tests/PVOutput.Net.Tests/Modules/System/SystemSystemTestsData.cs
@@ -8,7 +8,7 @@
 
         public const string SYSTEM_RESPONSE_SIMPLE = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,E,,No,,51.0,6.1,5;;";
         
-        public const string OWNSYSTEM_RESPONSE_WITHOUT_SECONDARYPANEL = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,E,53.0,No,,51.0,6.1,5,,,null,NaN;";
+        public const string OWNSYSTEM_RESPONSE_WITHOUT_SECONDARYPANEL = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,EW,53.0,No,,51.0,6.1,5,,,null,NaN;";
 
         public const string SYSTEM_RESPONSE_EXTENDED = "Test System,4125,1234,15,275,JA Solar mono,1,5500,Fronius Primo 3.6-1,E,53.1,No,20160822,51.0,6.1,5,10,190,W,33.5;17.37,20.46,20.2,25.4,22.65,40.0;12,232,480,512;1;DC-1 Voltage,V,DC-2 Voltage,V,DC-DC Booster Temp,°C,DC-1 Power (2x13x290Wp),W;61,106,252,380,430,425,417,354,253,159,70,48,400,350,300,250,200,150,100,175,275,375,475,525";
 


### PR DESCRIPTION
Added support for undocumented panel orientation EastWest, which clearly isn't part of the compass rose.

Fixes #129
